### PR TITLE
fix(GH-action): Update use npm instead of yarn

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,12 +18,12 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18
-          cache: yarn
+          cache: "npm"
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: npm install
       - name: Build website
-        run: yarn build
+        run: npm build
 
       - name: Upload Build Artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
This PR uses npm instead of yarn in deployment workflow