### PR TITLE
feat(docs): Import docs about Contact page

### DIFF
--- a/docs/contact.md
+++ b/docs/contact.md
@@ -1,0 +1,32 @@
+---
+sidebar_position: 7
+---
+
+# Contact us
+
+The data stewards of TU/e Research Data Management can be contacted via rdmsupport@tue.nl or via the contact details below:
+
+## Data Stewards
+
+- Angela Aleksovska (a.aleksovska@tue.nl)
+- Davide Nardi (d.nardi@tue.nl)
+- Lucia Forrová (l.forrova@tue.nl)
+- Jayakrishnan H R Nair (h.r.nair@tue.nl)
+- Neda Norouzi (n.norouzi1@tue.nl)
+- Mariana Oshima Menegon (m.oshima.menegon@tue.nl)
+- Liz Guzman Ramirez (l.guzman.ramirez@tue.nl)
+- Nami Sunami (n.sunami@tue.nl)
+
+## By Department
+
+| Department                                       | Data steward           |
+| ------------------------------------------------ | ---------------------- |
+| Applied Physics and Science Education            | Nami Sunami            |
+| Biomedical Engineering                           | Neda Norouzi           |
+| Built Environment                                | Lucia Forrová          |
+| Chemical Engineering &amp; Chemistry             | Nami Sunami            |
+| Electrical Engineering                           | Angela Aleksovska      |
+| Industrial Design                                | Mariana Oshima Menegon |
+| Industrial Engineering &amp; Innovation Sciences | Jayakrishnan H R Nair  |
+| Mathematics and Computer Science                 | Davide Nardi           |
+| Mechanical Engineering                           | Neda Norouzi           |


### PR DESCRIPTION
This PR imports the contact info of the data stewards from the public website.