### PR TITLE
chore(link-checker): Check link once a month

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -4,7 +4,7 @@ on:
   repository_dispatch:
   workflow_dispatch:
   schedule:
-    - cron: "00 18 * * *"
+    - cron: "00 00 1 * *"
 
 jobs:
   linkChecker:


### PR DESCRIPTION
This PR updates the PR so that the link checker only runs once a month. 

Fixes #34 