### PR TITLE
chore(gh-action): Allow writing contents to push to the gh-pages branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,7 @@ jobs:
 
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:
+      contents: write # to push the deployment to the repository
       pages: write # to deploy to Pages
       id-token: write # to verify the deployment originates from an appropriate source
 


### PR DESCRIPTION
This PR grants additional permission to the GitHub Action so that the action can push to the branch (gh-pages).