### PR TITLE
Copy only inner HTML of the examples

### DIFF
--- a/src/components/BlockQuoteWithCopy/index.tsx
+++ b/src/components/BlockQuoteWithCopy/index.tsx
@@ -6,11 +6,11 @@ export default function BlockQuoteWithCopy(props: React.PropsWithChildren) {
   const quoteRef = useRef<HTMLQuoteElement>(null)
 
   async function onCopyButtonClick() {
-    const outerHTML = quoteRef.current.outerHTML
+    const innerHTML = quoteRef.current.innerHTML
     const innerText = quoteRef.current.innerText
 
     const clipboardItem = new ClipboardItem({
-      ["text/html"]: outerHTML,
+      ["text/html"]: innerHTML,
       ["text/plain"]: innerText,
     })
 


### PR DESCRIPTION
This PR fixes the issue of block quotes being copied. Now clicking the button copies only the content of the example. 

Fixes #67 