### PR TITLE
Update the research data lifecycle image

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -17,4 +17,6 @@ For a quick start, check our general RDM guidelines and FAQ.
 
 Data management is a crucial aspect of the **research data lifecycle**, which involves the various stages of data handling from its inception to its ultimate disposition. Throughout the research data lifecycle, data management includes tasks such as planning your research, collecting data using various methods, processing and analysing data, organizing and documenting data, securely storing and preserving it, sharing it responsibly, and eventually properly disposing of or archiving it for future reuse. This systematic approach to data management ensures that research data remains reliable, accessible, and compliant with ethical and legal requirements, promoting transparency and contributing to better and more efficient scientific research.
 
-![Research Data Lifecycle](lifecycle.png)
+
+![Research Data Lifecycle](https://github.com/user-attachments/assets/c7da5598-56cc-46aa-9c39-8003d9e78617)
+


### PR DESCRIPTION
This PR replaces the research data lifecycle image for the intro page to match the site's theme.

from this: 
<img width="500" height="876" alt="Capture-2025-08-10-212012" src="https://github.com/user-attachments/assets/bad5aa74-9671-41f9-8190-04b1b59b3d62" />

to this:
<img width="500" height="856" alt="Capture-2025-08-10-211922" src="https://github.com/user-attachments/assets/f7c10256-0412-4b00-a7e0-3e97b175ac8a" />

Fixes #60 
