### PR TITLE
feat: Allow page preview from a fork

### DIFF
--- a/.github/workflows/build-deploy-and-preview.yml
+++ b/.github/workflows/build-deploy-and-preview.yml
@@ -1,7 +1,7 @@
 name: Deploy PR previews
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened

--- a/.github/workflows/build-deploy-and-preview.yml
+++ b/.github/workflows/build-deploy-and-preview.yml
@@ -1,7 +1,7 @@
 name: Deploy PR previews
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - reopened


### PR DESCRIPTION
This PR allows page preview from a fork by changing the action strategy from `pull_request` to `pull_request_target`. 

https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target

Fixes #74