### PR TITLE
fix: Update FAIR principles link in data repository documentation

### DIFF
--- a/docs/after-researcch/data-repository/data-repository.md
+++ b/docs/after-researcch/data-repository/data-repository.md
@@ -11,7 +11,7 @@ Benefits of using data repository:
 - Secure and reliable way to **store and manage** your data
 - **Long-term data preservation**
 - **Access control** and easy **sharing** with scientific community
-- Promotion and help with adhering to [**FAIR principles**](https://www.tue.nl/en/our-university/library/library-for-researchers-and-phds/research-data-management/rdm-themes/fair)
+- Promotion and help with adhering to [**FAIR principles**](/docs/before-research/FAIR/FAIR.md)
 - A **persistent identifier** (e.g. **DOI**, Handle) will be assigned to your dataset, which provides a permanent link to the data, making your data findable and citable.
 - Option to choose suitable **[license](https://www.tue.nl/en/our-university/library/library-for-researchers-and-phds/research-data-management/after-research/licensing)**, providing clarity for the potential user of your data whether and how re-use of your data is permitted (see licenses).
 - The requirement to add appropriate [**metadata**](https://www.tue.nl/en/our-university/library/library-for-researchers-and-phds/research-data-management/rdm-themes/documentation-and-metadata) to the data.


### PR DESCRIPTION
This PR fixes the link to the FAIR principles on the Data Repository page. The link was pointing to our old Typo3 website. 

