### PR TITLE
Update licensing documentation and improve section headings for clarity

### DIFF
--- a/docs/after-researcch/licensing/licensing.md
+++ b/docs/after-researcch/licensing/licensing.md
@@ -8,25 +8,33 @@ sidebar_position: 4
 
 Data licensing plays a pivotal role in fostering data sharing, transparency, and responsible use within the research community and beyond. Licenses stipulate whether data can be freely used, modified, redistributed, and under what conditions. Choosing the right license is crucial: open licenses promote collaboration and reuse, while more restrictive licenses may protect sensitive or proprietary information.
 
-Creative Commons licenses  
+### Creative Commons licenses
+
 The [**Creative Commons licenses**](https://creativecommons.org/licenses/) provide the opportunity to assign rights in re-using data, which are legal, human-readable and machine-readable. There are seven standard Creative Commons licenses where, in terms of data, CC0 and CC-BY are the most used licenses.
 
 Both of these licenses permit others to use, distribute, remix, adapt, and build upon the work, even for commercial purposes. CC0 allows for the broadest reuse without any attribution requirement. CC-BY should be used when you want to maximize openness and allow others to use and build upon your research data, while still ensuring proper credit is given to you as the original creator.
 
 The possible choices for the license to apply to your data may, however, be limited by the repository in which you store your data. **Creative Commons** provides [**a guide to determine the preferred license**](https://creativecommons.org/choose/).
 
-Open Database licenses  
+### Open Database licenses
+
 Another option for licensing your data is using [**Open Database licenses**](https://opendatacommons.org/index.html). While these are less commonly used, open database licenses clearly separate licensing the data(base) and the content created with it. For example, in a database full of photographs there are rights in the database and separate rights in the photographs. Open Database licenses (ODbL) for the database can be combined with Database Contents licenses (DbCL) for the photographs, or even combined with Creative Commons licenses and thus provide more flexibility.
+
+### FAQ
+
+**Which creative commons license should I use for my dataset?**  
+You should select a license that allows access to your data by as many people as possible, with the fewest restrictions. If you need help choosing a license, please [contact us](/docs/contact.md).
 
 ## Software Licensing
 
 A software license governs the use or redistribution of software. Without a license, all rights remain with the author of the code, meaning that nobody else can use, copy, distribute, or modify the software without permission. A license provides the permissions to use the software under well-defined conditions, so always license your software if you want to share it. **Licensing generally increases, not decreases, the openness of your software**.
 
-It is important to choose a license early, in particular when the development of the software is a collaborative effort. If no license is in place on time, a collaborator will hold copyright on each new contribution and will thus need to be asked for an approval when a license is chosen. Often, you also need to consider your licensing strategy in your **data management plan (**[**DMP**](https://www.tue.nl/en/our-university/library/library-for-researchers-and-phds/research-data-management/rdm-themes/data-management-plan)**).** It is recommended to add a LICENSE.txt file in the source directory of your software, or to mention add the license at the beginning of your code. That way you make sure that your license is visible to others.
+It is important to choose a license early, in particular when the development of the software is a collaborative effort. If no license is in place on time, a collaborator will hold copyright on each new contribution and will thus need to be asked for an approval when a license is chosen. Often, you also need to consider your licensing strategy in your **Data Management Plan (**[**DMP**](../../before-research/dmp/dmp.md)**).** It is recommended to add a LICENSE.txt file in the source directory of your software, or to mention add the license at the beginning of your code. That way you make sure that your license is visible to others.
 
-If further questions about data or software licenses remain, then please contact the data stewards of the [**RDM support team**](https://www.tue.nl/en/our-university/library/library-for-researchers-and-phds/research-data-management/rdm-training-and-courses)**.**
+If further questions about data or software licenses remain, then please contact the data stewards of the [**RDM support team**](../../contact.md)**.**
 
-**Selecting a software license**  
+### Selecting a software license
+
 Creative Commons licenses and Open Database licenses are suitable for data but not for software. Since they are not appropriate for software, a special **software license** should be used.
 
 First of all, when selecting a software license, it is important to determine who owns the research software you wrote. If you wrote the software as a part of your employment at TU/e, it is important to [consult with Innovation Lab](https://brainporteindhoven.com/the-gate/en/) to discuss any issues of ownership and intellectual property protection (particularly if patenting of the software is under consideration).
@@ -41,20 +49,13 @@ Some recommended licenses are:
 
 To select a license, you can use [**this tool**](https://choosealicense.com/), or follow [**these recommendations**](https://www.gnu.org/licenses/license-recommendations.html).
 
-## FAQ
-
-### Licenses
-
-**Which creative commons license should I use for my dataset?**  
-You should select a license that allows access to your data by as many people as possible, with the fewest restrictions. See our page on [data storage and sharing](https://www.tue.nl/en/our-university/library/library-for-researchers-and-phds/research-data-management/rdm-themes/data-storage-and-sharing) for more information. If you need help choosing a license, please [contact us](/docs/contact.md).
-
-### Software licenses
+### FAQ
 
 **Are Creative Commons (CC) licenses suitable for software?**  
 No, CC licenses are not suited for software licensing.
 
 **Which license should I use for my research software code?**  
-Consider a GPL-compatible license or a BSD-like/MIT license. You can find more information in the [Software](https://www.tue.nl/en/our-university/library/library-for-researchers-and-phds/research-data-management/rdm-themes/research-software) section.
+Consider a GPL-compatible license or a BSD-like/MIT license. You can find more information in the [Research Software](../../during-research/research-software/research-software.md) section.
 
 **I wrote a piece of software code for my research. Am I the owner of this code?**  
 TU/e is working on guidelines on this. If you have any questions regarding the IP-rights you can contact [The Gate](https://www.tue.nl/en/impact/the-gate).

--- a/docs/before-research/FAIR/FAIR.md
+++ b/docs/before-research/FAIR/FAIR.md
@@ -2,7 +2,7 @@
 sidebar_position: 5
 ---
 
-# FAIR data
+# FAIR Principles
 
 The [**FAIR principles**](https://www.go-fair.org/fair-principles/) are the standard for responsible data management and practicing open science. They focus on ensuring that research data are reusable, will actually be reused and will become as valuable as possible. FAIR is not only aimed at human beings but puts emphasis on enhancing the ability of machines to automatically find and use the data. FAIR stands for:
 

--- a/docs/before-research/reusing-data/reusing-data.md
+++ b/docs/before-research/reusing-data/reusing-data.md
@@ -2,7 +2,7 @@
 sidebar_position: 2
 ---
 
-# (Re)use of existing data
+# Data Reuse
 
 Instead of acquiring new data, it might be more efficient to reuse existing data. This may be data collected by others but also data you collected previously. Reusing research data offers numerous benefits to both individual researchers and the broader scientific community. In general, reusing research data is a practice that benefits researchers by saving time and resources, reducing data redundancy, improving the rigor of research through validation and reproducibility, enabling comparative and interdisciplinary studies, and promoting a collaborative scientific culture and knowledge exchange. Reusing existing data can sometimes be more ethically sound than collecting new data, especially when dealing with sensitive topics or vulnerable populations. It reduces the need to subject participants to additional data collection processes.
 


### PR DESCRIPTION
In Before Research section:
•	FAIR data > FAIR Principles
•	(Re)use of existing data > Data Reuse
In After Research > Data & Software Licensing
•	Added subtitles to Data Licensing 
•	Updated links that were taking to the old website
•	Removed sentence “See our page on [data storage and sharing](https://www.tue.nl/en/our-university/library/library-for-researchers-and-phds/research-data-management/rdm-themes/data-storage-and-sharing) for more information” as they are not related to licensing.