### PR TITLE
Align with confluence content

### DIFF
--- a/docs/after-research/data-preservation/data-preservation.md
+++ b/docs/after-research/data-preservation/data-preservation.md
@@ -81,6 +81,7 @@ Revisit archiving decisions periodically to ensure continued compliance with pol
 
 ### What is the difference between raw, processed, and analysed data?
 Raw data are the original data that you have collected but have not yet processed or analysed. For instance: audio files, archives, observations, field notes and data from experiments. Data you have not collected yourself and that you are reusing, may be considered raw data.  
+
 Processed data are the data that you have digitised, translated, transcribed, cleaned, validated, checked and/or anonymised.  
 Analysed data are the models, graphs, tables, texts and so on that you have created based on the raw and the processed data, and that are intended to aid in the discovery of useful information, the presentation of conclusions, and decision-making.
 

--- a/docs/after-research/data-preservation/data-preservation.md
+++ b/docs/after-research/data-preservation/data-preservation.md
@@ -80,10 +80,14 @@ Revisit archiving decisions periodically to ensure continued compliance with pol
 ## FAQ
 
 ### What is the difference between raw, processed, and analysed data?
-Raw data are the original data that you have collected but have not yet processed or analysed. For instance: audio files, archives, observations, field notes and data from experiments. Data you have not collected yourself and that you are reusing, may be considered raw data.  
+
+Raw data are the original data that you have collected but have not yet processed or analysed. For instance: audio files, archives, observations, field notes and data from experiments. Data you have not collected yourself and that you are reusing, may be considered raw data.
 
 Processed data are the data that you have digitised, translated, transcribed, cleaned, validated, checked and/or anonymised.  
 Analysed data are the models, graphs, tables, texts and so on that you have created based on the raw and the processed data, and that are intended to aid in the discovery of useful information, the presentation of conclusions, and decision-making.
 
+For more information, please see [Research Data](/docs/intro/research-data/research-data.md#raw-processed--analysed-data) page.
+
 ### Does TU/e have an archive for research data used in scientific publications?
+
 Yes. Data and other relevant documents associated with scientific publication can be archived in the [TU/e Research Archival Package Solution](https://cockpit.research.tue.nl/servicedesk/customer/portal/7).

--- a/docs/after-research/data-preservation/data-preservation.md
+++ b/docs/after-research/data-preservation/data-preservation.md
@@ -79,7 +79,7 @@ Revisit archiving decisions periodically to ensure continued compliance with pol
 
 ## FAQ
 
-**What is the difference between raw, processed, and analysed data?**  
+### What is the difference between raw, processed, and analysed data?
 Raw data are the original data that you have collected but have not yet processed or analysed. For instance: audio files, archives, observations, field notes and data from experiments. Data you have not collected yourself and that you are reusing, may be considered raw data.  
 Processed data are the data that you have digitised, translated, transcribed, cleaned, validated, checked and/or anonymised.  
 Analysed data are the models, graphs, tables, texts and so on that you have created based on the raw and the processed data, and that are intended to aid in the discovery of useful information, the presentation of conclusions, and decision-making.

--- a/docs/after-research/data-preservation/data-preservation.md
+++ b/docs/after-research/data-preservation/data-preservation.md
@@ -4,72 +4,11 @@ sidebar_position: 1
 
 # Data Preservation
 
-## Archiving Data
+## Archiving data
 
-Generating data and software as well as publishing results in scientific journals take a lot of effort. Thus, it is important to properly archive your research output. Archiving data means that you ensure that a copy of your dataset is kept in a secure location for the long term (10 years or more).
+Generating data and software as well as publishing results in scientific journals take a lot of effort. Thus, it is important to properly archive your research output. Archiving data means that you ensure that [definitive data](/docs/intro/research-data/research-data.md#active--definitive-data) is kept in a secure location for the long term (10 years or more). The purpose of archiving may vary, including research integrity, future reuse, reproducibility, or compliance with funding or institutional requirements.
 
-Research data is all information, digital and non-digital, generated as part of the scientific process, on which scientific conclusions are based. In the research data lifecycle, it is important to differentiate between the stage where data is actively undergoing analysis (referred to as mutable data) and the phase where research data has been processed and has reached a stable state (known as immutable data). A similar differentiation is also applicable to storage and archiving systems, as they entail distinct functional and technical prerequisites.
-
-Deciding which research data to archive involves careful evaluation of different factors to ensure that valuable and relevant data are preserved for future use. Here's a step-by-step process to help you make informed decisions about archiving research data:
-
-**Define Archiving Goals and Criteria**
-
-- Identify the purpose of archiving: Is it for research integrity, future reference, data sharing, reproducibility, or compliance with funding or institutional requirements? (See in the table below which files need to be saved for the purpose of research integrity and reuse of data.)
-- Determine the criteria for data selection: Consider factors such as data quality, significance, uniqueness, potential for reuse, and alignment with your research objectives.
-
-**Assess Data Value and Significance**
-
-- Evaluate the importance of the data to your research outcomes and conclusions.
-- Consider the potential value of the data to other researchers, disciplines, or future studies.
-- Prioritize data that underpin published findings or have the potential to contribute to new insights.
-
-**Consider Ethical and Legal Considerations**
-
-- Ensure that the data to be archived comply with ethical standards, privacy regulations, and data protection laws.
-- Anonymize or de-identify sensitive or personal information as necessary.
-- Obtain necessary permissions or consents for data sharing and archiving, especially for human subjects data.
-
-**Assess Data Quality and Documentation**
-
-- Ensure that the data are [**well-documented**](/docs/during-research/docs-and-metadata), properly [**organized**](/docs/during-research/data-organization), and adequately described.
-- Include metadata that provide context, methods, variables, and any relevant information for understanding the data.
-
-**Evaluate Reusability and Reproducibility**
-
-- Choose data that can be easily understood and reused by others, facilitating reproducibility and validation.
-- Consider whether the data and associated documentation are sufficient to replicate your research methods and findings.
-
-**Select Data with Long-Term Value**
-
-- Focus on data that have enduring relevance, regardless of current trends or specific project timelines.
-- Prioritize data that contribute to broader scientific knowledge and have the potential for continued impact.
-
-**Include Raw and Processed Data**
-
-- Whenever possible, archive both raw and processed data, as well as any intermediate results or transformations.
-- Raw data enable others to apply different analyses and methods, while processed data showcase your research approach.
-
-**Consider Data Granularity**
-
-- Decide whether to archive comprehensive datasets or subsets that are most relevant to specific research questions or areas.
-
-**Involve Collaborators and Stakeholders**
-
-- Discuss data archiving decisions with co-authors, collaborators, or other stakeholders to ensure a shared understanding and agreement.
-
-**Document Archiving Decisions**
-
-- Maintain clear records of the data archiving process, including the rationale for selecting or excluding specific datasets.
-
-**Use Data Repositories**
-
-- Choose reputable [**data repositories**](/docs/after-research/data-repository) that align with your field of research and offer appropriate metadata and access options.
-
-**Review and Update**
-
-- Regularly review and update your archiving decisions to ensure they align with evolving research goals and practices.
-
-Two factors come into play when determining the data to be archived at a minimum: the motivation to preserve data for research integrity and the desire to facilitate data sharing among fellow researchers.
+Deciding which research data to archive involves consideration of the purpose and a careful evaluation of different factors (such as data quality, significance, uniqueness, potential for reuse, and alignment with your research objectives) to ensure that valuable and relevant data are preserved. The table below provides a summary of what should be archived depending for research integrity and data reuse purposes. Check the next section for more information.
 
 | Perspective of scientific integrity                                                                 | Perspective of reuse of data                                                                        |
 | --------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
@@ -80,12 +19,70 @@ Two factors come into play when determining the data to be archived at a minimum
 | Approval letter from the Ethical Review Board                                                       | &nbsp;                                                                                              |
 | If applicable: Data Management Plan                                                                 | &nbsp;                                                                                              |
 
+## Data retention & minimization
+
+The below checklist will help you define whether a given dataset is worth including to the archival package. Broadly speaking, consider three categories of reasons (1) documentation & reproducibility, (2) scientific value, and (3) policy & legal compliance.
+
+### Documentation & reproducibility
+
+#### 💾 Reasons to retain data
+
+- Data are sufficiently [**documented**](/docs/during-research/docs-and-metadata), [**organized**](/docs/during-research/data-organization), and accompanied by metadata (e.g. methods, variables, file structure) so that others can understand and reuse them.
+- Data that can be easily understood and reused by others, facilitating reproducibility and validation.
+- Whenever possible, raw and processed data, as well as any intermediate results or transformations should be kept alongside the analyzed data.
+
+#### 🗜️ Reasons to minimize or remove data
+
+- Data lack essential documentation or contextual information and cannot reasonably be made understandable.
+- Data are redundant because equivalent, better-documented versions are already archived.
+
+### Scientific value
+
+#### 💾 Reasons to retain data
+
+- Data is required for reproducing the results of the published results (that is, data in original form or data representing the publication).
+- Data is unique, and thus impossible or impractical to reproduce.
+- Data represent a landmark discovery or new precedent.
+
+#### 🗜️ Reasons to minimize or remove data
+
+- Data is intermediary or test data, which is neither the original data nor the analysis dataset for the publication.
+- Data can easily be reproduced with minimal effort (e.g., via code).
+- The quality of data is poor (corrupted files, insufficient precision of measurement data, etc.) or not well-documented what makes it impossible to reuse.
+
+### Policy & legal compliance
+
+#### 💾 Reasons to retain data
+
+- You promised to retain data in a contract.
+- Funding body or a journal requires you to retain the data (e.g., NWO asks archiving data at least for 10 years).
+- Data may be used in future legal procedures (e.g., litigation, police investigations, Freedom of Information requests).
+
+#### 🗜️ Reasons to minimize or remove data
+
+- You promised to remove certain data to your participants or your data provider.
+- You've promised to delete data at the end of the project in a contract.
+- You have personal data, and you want an extra layer of protection for privacy (e.g., destroying raw video or audio recording before archiving, applying pseudonymization or anonymization).
+
+> Data that include personal data cannot be archived indefinitely, and its limitations are already defined within the informed consent letters, and privacy agreement.
+>
+> [_Data sovereignty, data governance and digital sovereignty_, LCRDM](https://zenodo.org/records/10837008)
+
+Choose the best option for your situation to protect research participants' privacy while preserving valuable research data. Ensure you retain only the data necessary to demonstrate the integrity of the research. If any personal data is not essential for this purpose, consider removing it.
+
+After considering the reasons mentioned above, it might still not be entirely straightforward whether to keep your data, as this decision can involve subjective judgment. Archiving decisions should be made consciously and, where relevant, in consultation with collaborators or co-authors. Keep a brief record of:
+
+- Which data were included or excluded
+- The rationale for these decisions (e.g. scientific value, legal constraints, privacy considerations)
+
+Revisit archiving decisions periodically to ensure continued compliance with policies and alignment with good research practice.
+
 ## FAQ
 
 **What is the difference between raw, processed, and analysed data?**  
 Raw data are the original data that you have collected but have not yet processed or analysed. For instance: audio files, archives, observations, field notes and data from experiments. Data you have not collected yourself and that you are reusing, may be considered raw data.  
 Processed data are the data that you have digitised, translated, transcribed, cleaned, validated, checked and/or anonymised.  
-Analysed data are the models, graphs, tables, texts and so on that you have created based on the raw and the processed data, and that are intended to aid in the discovery of useful information, the presentation of conclusions, and decision-making
+Analysed data are the models, graphs, tables, texts and so on that you have created based on the raw and the processed data, and that are intended to aid in the discovery of useful information, the presentation of conclusions, and decision-making.
 
-**Does TU/e have an archive for research data?**  
-No. At the moment there is no archive at TU/e for long-term storage of research data.
+**Does TU/e have an archive for research data used in scientific publications?**  
+Yes. Data and other relevant documents associated with scientific publication can be archived in the [TU/e Research Archival Package Solution](https://cockpit.research.tue.nl/servicedesk/customer/portal/7).

--- a/docs/after-research/data-preservation/data-preservation.md
+++ b/docs/after-research/data-preservation/data-preservation.md
@@ -85,5 +85,5 @@ Raw data are the original data that you have collected but have not yet processe
 Processed data are the data that you have digitised, translated, transcribed, cleaned, validated, checked and/or anonymised.  
 Analysed data are the models, graphs, tables, texts and so on that you have created based on the raw and the processed data, and that are intended to aid in the discovery of useful information, the presentation of conclusions, and decision-making.
 
-**Does TU/e have an archive for research data used in scientific publications?**  
+### Does TU/e have an archive for research data used in scientific publications?
 Yes. Data and other relevant documents associated with scientific publication can be archived in the [TU/e Research Archival Package Solution](https://cockpit.research.tue.nl/servicedesk/customer/portal/7).

--- a/docs/intro/research-data/research-data.md
+++ b/docs/intro/research-data/research-data.md
@@ -13,6 +13,8 @@ Research data refers to the information, records, and observations collected or 
 - Images and audio/video recordings
 - Interview questions and transcripts
 
+## Raw, processed & analyzed data
+
 At different stages of the research, research data can be classified in the following types:
 
 - **Raw data** is the original data that you have collected but have
@@ -32,6 +34,17 @@ At different stages of the research, research data can be classified in the foll
   final models, graphs, tables and texts from your final report or
   scientific article.
 
-There are several ways to classify and define research data types besides the research stage. Other valuable classifications include its nature (qualitative or quantitative), collection method (experimental, simulation, interview, observational, or secondary data), and level of confidentiality or protection the data requires.
+## Active & definitive data
+
+It is also useful to distinguish the types of data above between active and definitive data.
+
+- **Active or mutable data** refers to data that are still subject to change, such as data being collected or actively processed and/or analyzed.
+- **Definitive or immutable data** refers to data that have reached a stable state and are no longer expected to change, for example the datasets underlying published results.
+
+Active data typically require flexible working environments, while definitive data should be preserved in a stable and well-documented form to ensure long-term accessibility, reproducibility, and integrity.
+
+## Other classifications
+
+There are several ways to classify and define research data types besides the ones you see above. Other valuable classifications include its nature (qualitative or quantitative), collection method (experimental, simulation, interview, observational, or secondary data), and level of confidentiality or protection the data requires.
 
 Knowing what type of data you are working with is important because it affects how you should handle and store it. Some data may come with specific requirements or restrictions. For example, if your dataset includes personal data, you will need to follow data protection laws and ethical guidelines. This kind of data is typically classified as having a medium to high confidentiality level, which means it must be stored securely using appropriate technical and organizational safeguards. You may also need to take extra steps like de-identifying the data or using client-side encryption to protect it. These and other considerations will be explained further in section [Privacy in Research](/docs/category/privacy-in-research).

--- a/docs/intro/research-data/research-data.md
+++ b/docs/intro/research-data/research-data.md
@@ -13,12 +13,12 @@ Research data refers to the information, records, and observations collected or 
 - Images and audio/video recordings
 - Interview questions and transcripts
 
-## Raw, processed & analyzed data
+## Raw, processed & analysed data
 
 At different stages of the research, research data can be classified in the following types:
 
 - **Raw data** is the original data that you have collected but have
-  not yet processed or analyzed. This can include data from various
+  not yet processed or analysed. This can include data from various
   collection methods such as experiments, computer simulations,
   interviews, and observations. Data you have not collected yourself,
   but obtained from others for reuse (secondary data), may be
@@ -27,7 +27,7 @@ At different stages of the research, research data can be classified in the foll
   transcribed, cleaned, organized, transformed, anonymized, validated
   and checked, making it suitable for analysis. This can include steps
   like removing errors, normalizing values, or converting formats.
-- **Analyzed data** is data that has been examined and interpreted
+- **Analysed data** is data that has been examined and interpreted
   to draw conclusions or insights. This involves applying statistical
   methods, algorithms, or other analytical techniques to processed
   data. This is usually the data that is represented or included in the
@@ -38,7 +38,7 @@ At different stages of the research, research data can be classified in the foll
 
 It is also useful to distinguish the types of data above between active and definitive data.
 
-- **Active or mutable data** refers to data that are still subject to change, such as data being collected or actively processed and/or analyzed.
+- **Active or mutable data** refers to data that are still subject to change, such as data being collected or actively processed and/or analysed.
 - **Definitive or immutable data** refers to data that have reached a stable state and are no longer expected to change, for example the datasets underlying published results.
 
 Active data typically require flexible working environments, while definitive data should be preserved in a stable and well-documented form to ensure long-term accessibility, reproducibility, and integrity.


### PR DESCRIPTION
Main goal was to align website content ("Data Preservation" section) with confluence content ("Data retention and minimization guidelines"), in https://cockpit.research.tue.nl/servicedesk/customer/portal/7/article/2415034451?source=search

For that, the definition of active and definitive data was added to section "Research Data" 
<img width="1405" height="754" alt="image" src="https://github.com/user-attachments/assets/bc5623c8-e926-40b6-be36-e5d8dd982576" />

Then section "Data Preservation" got a new section on data retention and minimization that partially aligns with the content in confluence (differences to be discussed)
<img width="1441" height="804" alt="image" src="https://github.com/user-attachments/assets/7e70aea9-f7f3-4db6-ae8b-d3454d219dd4" />

Also the answer to the question about TU/e archive in the FAQ was also updated with RAPS information  