### PR TITLE
feat(navbar): Add a link to Research Cockpit

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -84,6 +84,12 @@ const config: Config = {
         },
         { to: "/blog", label: "Blog", position: "left" },
         {
+          href: "https://cockpit.research.tue.nl",
+          label: "Research Cockpit",
+          position: "right",
+        },
+
+        {
           href: "https://github.com/tue-datastewards/research-data-management-handbook",
           label: "GitHub",
           position: "right",


### PR DESCRIPTION
This PR adds a link to Research Cockpit in the Nav Bar

<img width="706" height="113" alt="image" src="https://github.com/user-attachments/assets/2d4df1c4-0507-40b5-92b3-250275e99b20" />

Fixes #180
