### PR TITLE
feat(ethical-approval): Add a CTA button linking to Cockpit

### DIFF
--- a/docs/before-research/dmp/dmp.md
+++ b/docs/before-research/dmp/dmp.md
@@ -29,7 +29,7 @@ A typical Data Management Plan includes the following key elements:
 - [**Data Sharing and Accessibility**](../../during-research/storage-and-sharing/)  
   When applicable, a simple statement declaring that all data is suitable for re-use is adequate. However, if certain data is unsuitable for re-use due to reasons such as privacy or intellectual property concerns, a clear explanation must be provided. It is essential to specify whether these restrictions apply to the entire dataset or only specific portions, such as raw data, interview data, or confidential data, which may not be suitable for re-use. If you indicated that some or all of the data is suitable for re-use, it is crucial to specify the intended data sharing location. Typically, funders expect you to mention a specific trustworthy repository (e.g., 4TU.ResearchData, Zenodo, DANS, etc.) and clarify whether the repository provides a persistent identifier, such as a DOI (Digital Object Identifier). This ensures the data's accessibility and long-term traceability.
 
-- Data Security and [Ethical](../../before-research/ethical-approval/ethical-approval.md) Considerations  
+- Data Security and [Ethical](../../before-research/ethical-approval) Considerations  
   Here, you describe the measures you will take to protect the privacy and confidentiality of sensitive data, as well as compliance with ethical guidelines, data protection regulations, and any necessary consent procedures.
 
 - Intellectual Property Rights  

--- a/docs/before-research/ethical-approval/ethical-approval.mdx
+++ b/docs/before-research/ethical-approval/ethical-approval.mdx
@@ -2,9 +2,15 @@
 sidebar_position: 6
 ---
 
+import ApplyERB from "@site/src/components/ApplyERB";
+
 # Ethical Approval
 
 Everyone with TU/e affiliation (including students) must register their research involving human participants and ask for ethical approval. Ethical approval is also necessary when processing data from human participants that were collected by an external party, which is considered the processing of secondary data.
+
+<ApplyERB />
+
+## When do I need an ethical approval?
 
 If your research or educational activity involves one of the following items, you need to register your research project for [**ethical review**](https://tuenl.sharepoint.com/sites/intranet-ethical-review/SitePages/Organisatie.aspx):
 
@@ -34,6 +40,6 @@ If necessary, consult a data steward on RDM and privacy-related sections of the 
 
 ## FAQ  
 
-**I am planning a research project that involves human participants and/or personal data. What steps should I take before I can start?**
+### I am planning a research project that involves human participants and/or personal data. What steps should I take before I can start?
 
 Before you start your research involving human participants and/or personal data, you need to obtain ethical approval. Please visit the [Ethical Review Board](https://www.tue.nl/en/our-university/about-the-university/integrity/tue-ethical-review-board/) page to select a process that applies to your situation. You can also download the ERB form, which needs to be completed for your ERB application. If you have questions regarding privacy topics or need support completing the ERB form, contact a [Data Steward](/docs/contact.md).

--- a/src/components/ApplyERB/index.tsx
+++ b/src/components/ApplyERB/index.tsx
@@ -1,0 +1,13 @@
+export default function ApplyERB() {
+  return (
+    <>
+      <a
+        class="button button--primary"
+        href="https://cockpit.research.tue.nl"
+        target="_blank"
+      >
+        Apply for an ERB on Research Cockpit
+      </a>
+    </>
+  );
+}


### PR DESCRIPTION
This PR adds a button linking to Research Cockpit on the Ethical approval page

<img width="1702" height="562" alt="image" src="https://github.com/user-attachments/assets/61802c67-01d7-4145-8a17-1bf57036dd95" />

Fixes #155 
