### PR TITLE
fix(ReadyToStartDMP): Use <a> tag instead of <button>

### DIFF
--- a/src/components/ReadyToStartDMP/index.tsx
+++ b/src/components/ReadyToStartDMP/index.tsx
@@ -22,14 +22,13 @@ export default function ReadyToStartDMP(): ReactNode {
           You can also start an Ethical Approval, or request research tools
           available at TU/e.
         </p>
-        <button
+        <a
           className="button button--primary button--lg"
-          onClick={() =>
-            window.open("https://cockpit.research.tue.nl", "_blank")
-          }
+          href="https://cockpit.research.tue.nl"
+          target="_blank"
         >
           Go to Research Cockpit
-        </button>
+        </a>
       </div>
     </section>
   );


### PR DESCRIPTION
I'm making this PR to update <button> tag to <a> tag, since the button is actually a link that's styled as a button. 

Technically, <button> should perform an action (such as submitting a form, or opening a dialog) as per [MDN doc](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#:~:text=Once%20activated%2C%20it%20then%20performs%20an%20action%2C%20such%20as%20submitting%20a%20form%20or%20opening%20a%20dialog).