### PR TITLE
Add the new page for FAIR Data Clinic

### DIFF
--- a/docs/learning-resources/fair-clinic/fair-clinic.mdx
+++ b/docs/learning-resources/fair-clinic/fair-clinic.mdx
@@ -30,11 +30,11 @@ The goal is to improve your current practice step by step and, at the same time,
 
 ## How to register
 
-1. Send your request to join the clinic to **Davide Nardi** (Data Steward) via email at: [d.nardi@tue.nl](mailto:d.nardi@tue.nl).
+1. Email **Davide Nardi** (Data Steward) to request to join the clinic at: [d.nardi@tue.nl](mailto:d.nardi@tue.nl).
    {<a class="button button--primary" href="mailto:d.nardi@tue.nl" target="_blank">
    Email Davide</a>}
 
-2. Answer the following form, so that we can evaluate your needs in advance and provide you with tailored recommendations during the session: [FAIR Clinic questionnaire – Fill out form](#)
-   {<a class="button button--primary" href="" target="_blank">
+2. Answer the [FAIR Clinic Questionnaire](https://forms.office.com/Pages/ResponsePage.aspx?id=R_J9zM5gD0qddXBM9g78ZJxGBrYlN4RBsdVuods0q75UMDRPVkk5VFZJUTE1MzFaQ1BEUkQyUEVMRi4u), so that we can evaluate your needs in advance and provide you with tailored recommendations during the session.
+   {<a class="button button--primary" href="https://forms.office.com/Pages/ResponsePage.aspx?id=R_J9zM5gD0qddXBM9g78ZJxGBrYlN4RBsdVuods0q75UMDRPVkk5VFZJUTE1MzFaQ1BEUkQyUEVMRi4u" target="_blank">
    Fill out the FAIR Clinic Questionnaire</a>}
    See you there!

--- a/docs/learning-resources/fair-clinic/fair-clinic.mdx
+++ b/docs/learning-resources/fair-clinic/fair-clinic.mdx
@@ -1,0 +1,40 @@
+---
+sidebar_position: 4
+---
+
+# FAIR Data Clinic
+
+## Monthly FAIR Data Clinic: Make Your Data More Useful (for You and Others)
+
+Do you have a dataset or a script collection that you'd like to organise better, document properly, or prepare for (future) sharing?
+
+Join our monthly **FAIR Data Clinic**: a practical working session where we look at one of your research outputs and identify simple, concrete steps to make it more **Findable, Accessible, Interoperable and Reusable**. Not only will your data get more valuable to other people, but you will also become compliant with the Research Data Management Framework Policy at TU/e.
+
+## What you can expect
+
+- A 20 minute slot focused on your data or code.
+- Help to clarify: where it lives, how it's structured, who needs access, and what minimal documentation/metadata would really help.
+- A short **"FAIR improvement plan"** with 2–3 realistic next actions.
+
+## What this is not
+
+- Formal legal/IP or GDPR advice.
+- A guarantee that your data is "fully FAIR compliant" after one session.
+
+The goal is to improve your current practice step by step and, at the same time, to build more in-depth and practical FAIR expertise within the university's data stewardship.
+
+## Session Details
+
+- The FAIR clinic is an **in-person session** that will take place on the **first Thursday of each month**, between **13:00–14:00**, in meeting room **Atlas 10.220**.
+- For each session there are **three slots** available.
+
+## How to register
+
+1. Send your request to join the clinic to **Davide Nardi** (Data Steward) via email at: [d.nardi@tue.nl](mailto:d.nardi@tue.nl).
+   {<a class="button button--primary" href="mailto:d.nardi@tue.nl" target="_blank">
+   Email Davide</a>}
+
+2. Answer the following form, so that we can evaluate your needs in advance and provide you with tailored recommendations during the session: [FAIR Clinic questionnaire – Fill out form](#)
+   {<a class="button button--primary" href="" target="_blank">
+   Fill out the FAIR Clinic Questionnaire</a>}
+   See you there!

--- a/docs/learning-resources/others/others.md
+++ b/docs/learning-resources/others/others.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 # External Resources


### PR DESCRIPTION
This PR adds the new page for FAIR Data Clinic.

I placed it under the Skill-Building and Learning section.

<img width="2436" height="4010" alt="image" src="https://github.com/user-attachments/assets/13ef1eb2-636f-48ac-8a9a-130f251f156c" />
