### PR TITLE
feat(docs): Render last updated date on each page

### DIFF
--- a/.github/workflows/build-deploy-and-preview.yml
+++ b/.github/workflows/build-deploy-and-preview.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Full history needed to compute last-updated dates
 
       - name: "Save Preview Path"
         run: echo "PREVIEW_PATH=pr-preview/pr-${{ github.event.number }}" >> "$GITHUB_ENV"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout repository 📂
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Full history needed to compute last-updated dates
 
       - name: Install and build 🔧
         run: |

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -39,6 +39,9 @@ const config: Config = {
       {
         docs: {
           sidebarPath: "./sidebars.ts",
+          // Automatically render "Last updated on <date>" on each doc page,
+          // sourced from Git history at build time.
+          showLastUpdateTime: true,
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:


### PR DESCRIPTION
Enable Docusaurus built-in showLastUpdateTime to auto-render the last Git commit date on every doc page. Add fetch-depth: 0 to both deploy workflows so CI builds have full history to compute the dates.

Closes #113