### PR TITLE
docs(contributing): Add CONTRIBUTING.md, PR/issue templates, and Code of Conduct excerpt

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_content_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_content_report.md
@@ -1,0 +1,19 @@
+---
+name: Bug / content report
+about: Report a broken link, typo, factual error, or outdated information in the handbook
+title: ""
+labels: bug
+assignees: []
+---
+
+## Where is the problem?
+
+**Page URL:** <!-- e.g. https://rdm.tue.nl/docs/before-research/dmp -->
+
+## What's wrong and what did you expect?
+
+<!-- Describe the issue (broken link, typo, outdated info, factual error) and what the page should say or do instead. -->
+
+## Screenshot (optional)
+
+<!-- If helpful, paste a screenshot. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Description
+
+<!-- Briefly describe what this PR changes and why. -->
+
+## Before / after (optional)
+
+<!-- If the change is visual (layout, styling, images), paste before/after screenshots. Skip for text-only changes. -->
+
+| Before | After |
+| ------ | ----- |
+|        |       |

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,64 @@
+# Code of Conduct
+
+This is a summary of the [TU/e Code of Conduct](https://assets.w3.tue.nl/w/fileadmin/content/Our_University/About%20our%20university/Integrity%20and%20social%20safety/CodeofConduct_TUe.pdf) (PDF), adapted for contributors to this project. It is provided for convenience; the full TU/e Code of Conduct is authoritative and applies in case of any conflict or ambiguity.
+
+## Who this applies to
+
+The TU/e Code of Conduct is the framework for the behaviour expected from everyone within the TU/e community — staff, students, councils, executive, advisory and supervisory bodies, and (temporary) guests. It covers all conduct a member engages in as part of their studies, student life, or work, whether on TU/e premises, in an academic setting elsewhere (e.g. a conference), or online (e.g. an online lecture or TU/e social media channels). Anyone using TU/e's facilities and premises is also expected to adhere to it.
+
+## Our CORe values
+
+TU/e strives to be a people-oriented organization: a stimulating, safe environment for a diverse community. This culture is expressed in the **CORe** values, which we ask every contributor to uphold:
+
+- **Curious** — We cherish curiosity, driving us to explore, question, and innovate, and encourage continuous learning and discovery. We are ambitious and professional.
+- **Open** — We value an open, accessible culture and are approachable. We are transparent and trustworthy about our actions, and foster open interdisciplinary collaboration with respect for all fields of expertise.
+- **Respectful** — We care for each other and are empathetic in our interactions. We welcome people from diverse backgrounds and perspectives, and make sure everybody is safe, supported, and seen.
+- **Responsible** — We lead by example and aim to make a positive impact on society. Sustainability is a moral consideration in all our activities. We are accountable for our work and our contributions.
+
+We aim to foster a culture in which everyone feels safe, respected, responsible, and acts with integrity — where everyone can voice their opinions, suggest ideas, give feedback, and challenge each other to do better. We commit to open dialogue, even on sensitive topics and when behaviour is not in line with these values.
+
+## Expected behaviour
+
+As contributors (colleagues and scientists), we expect a professional and respectful attitude in all interactions and collaborations: integrity, diligence in actions and communication, respect for expertise, and accountability for your actions. We respect diversity, are empathic towards one another, communicate openly, and are trustworthy.
+
+When contributing content that touches on research, we conduct ourselves carefully and in line with the Netherlands Code of Conduct for Research Integrity — Honesty, Scrupulousness, Transparency, Independence, and Responsibility — which implies proper data handling, reliable reporting of results, and no fraud or plagiarism.
+
+We take care not to misuse TU/e's or this project's resources, and we follow safety and other related regulations where applicable.
+
+## Undesirable behaviour
+
+We do not tolerate any form of undesirable behaviour or integrity violation — in the real or digital world — that is unduly stressful to a person because it jeopardises or injures their bodily, mental, or scientific integrity. This includes, but is not limited to:
+
+- physical or verbal (micro) aggression
+- (sexual) harassment
+- bullying, exclusion, or discrimination
+- (scientific or organisational) misbehaviour
+- abuse of (hierarchical) authority
+- privacy or copyright violations
+
+For privacy reasons it is forbidden to secretly capture and/or share image, video, or audio material of TU/e premises or people without a valid reason, and to use harmful AI-generated or deepfake material involving TU/e premises or people.
+
+Critical, yet respectful reflection or feedback on someone's behaviour or performance can feel unpleasant, but is **not** undesirable behaviour. Occasional, unintended awkward comments or blunders should ideally be addressed directly first, giving the person an opportunity to set matters right. Regular or recurring comments or actions that many would perceive as offensive or hurtful, however, do constitute integrity violations.
+
+## Bystanders
+
+Bystanders who witness undesirable behaviour or an integrity violation make an essential contribution to an honest and socially safe community. We encourage bystanders to step forward — either by talking directly to the person responsible, or by seeking help (see below).
+
+## What to do if you experience or witness a violation
+
+If you witness or become involved in an interaction that makes you feel uncomfortable, we recommend — if at all possible — talking about it with the person involved. Open dialogue is often a good way to resolve unpleasant situations.
+
+If that is not possible or sufficient, please report it:
+
+- For matters related to **this project**, contact the TU/e data stewards at **rdmsupport@tue.nl**.
+- For **TU/e-wide** matters, contact the TU/e **Integrity & Social Safety (I&SS) Desk**, or a (educational) manager, or someone within the care and support landscape for students or staff. See the [full TU/e Code of Conduct](https://assets.w3.tue.nl/w/fileadmin/content/Our_University/About%20our%20university/Integrity%20and%20social%20safety/CodeofConduct_TUe.pdf) and TU/e's I&SS website for details.
+
+Every report will get the required attention and will be treated in a consistent and fair manner towards all people involved.
+
+## Consequences
+
+Confirmed breaches of the Code of Conduct may lead to sanctions befitting the nature and severity of the violation. TU/e has a sanction policy in place, ranging from minor sanctions such as reprimands to more severe measures including suspension. The severity of any measure is proportionate to the seriousness of the behaviour, and the personal situation and other important circumstances are taken into account.
+
+## Attribution
+
+This summary is adapted from the [TU/e Code of Conduct](https://assets.w3.tue.nl/w/fileadmin/content/Our_University/About%20our%20university/Integrity%20and%20social%20safety/CodeofConduct_TUe.pdf). The full document is the authoritative source. For specific rules and regulations (e.g. codes for student and sports associations, education and exam regulations, the scientific code of conduct, and the procedure for reporting undesirable behaviour), see TU/e's Integrity & Social Safety (I&SS) website.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,169 @@
+# Contributing to the Research Data Management Handbook
+
+Thanks for your interest in improving the TU/e Research Data Management (RDM) Handbook! 🎉
+
+This handbook is a community effort. Whether you spotted a broken link, want to fix a typo, add a new page, or suggest a bigger improvement — every contribution is welcome. You don't need to be a developer to contribute; most changes are plain Markdown text.
+
+This guide walks you through how to do it. If anything is unclear, you can always email us at rdmsupport@tue.nl.
+
+## Table of contents
+
+- [Code of Conduct](#code-of-conduct)
+- [Ways to contribute](#ways-to-contribute)
+- [Set up the development environment](#set-up-the-development-environment)
+- [Make a change](#make-a-change)
+- [Report a bug or content error](#report-a-bug-or-content-error)
+- [Suggest an enhancement](#suggest-an-enhancement)
+- [Pull request process](#pull-request-process)
+- [Recognition](#recognition)
+- [Where to get help](#where-to-get-help)
+- [License](#license)
+
+## Code of Conduct
+
+Everyone participating in this project is expected to follow our [Code of Conduct](CODE_OF_CONDUCT.md). Please read it. Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the maintainers at rdmsupport@tue.nl.
+
+## Ways to contribute
+
+You can contribute in many ways:
+
+- 🐛 **Report a bug or content error** — broken links, typos, outdated info, factual mistakes. See [Report a bug or content error](#report-a-bug-or-content-error).
+- ✏️ **Fix something small** — a typo, a broken link, rewording a sentence.
+- 📄 **Add or improve a page** — new guidance, a new section, better examples.
+- 💡 **Suggest an enhancement** — propose a new feature or larger change. See [Suggest an enhancement](#suggest-an-enhancement).
+- 🔗 **Fix a broken link** — Docusaurus checks links automatically, but some still slip through.
+
+No contribution is too small.
+
+## Set up the development environment
+
+The handbook is built with [Docusaurus](https://docusaurus.io/). To preview your changes locally you'll need [Node.js](https://nodejs.org/) (version 18 or higher).
+
+1. **Fork** the repository on GitHub (top-right "Fork" button).
+
+2. **Clone your fork** locally:
+
+   ```bash
+   git clone git@github.com:YOUR_USERNAME/research-data-management-handbook.git
+   cd research-data-management-handbook
+   ```
+
+3. **Install dependencies:**
+
+   ```bash
+   npm install
+   ```
+
+4. **Start the development server:**
+
+   ```bash
+   npm start
+   ```
+
+   This opens http://localhost:3000/ in your browser. Changes you save reload automatically.
+
+To check that everything builds cleanly (no broken links, no type errors), run:
+
+```bash
+npm run build
+```
+
+## Make a change
+
+### 1. Create a branch
+
+Branch off from `main`. Use the pattern `<your-name>/<issue-or-PR-number>-<short-description>`:
+
+```bash
+git checkout -b nami/123-fix-broken-link
+```
+
+This makes it easy to see who is working on what and to trace a branch back to its issue or PR.
+
+### 2. Make your edit
+
+There are two easy ways to edit a page:
+
+- **From the website:** Click "Edit this page" at the bottom of any handbook page. This opens the file on GitHub, where you can edit and commit directly to a new branch on your fork.
+- **Locally:** Open the relevant Markdown file in `docs/` and edit it. The folder structure mirrors the handbook sections (e.g. `docs/before-research/`, `docs/during-research/`, `docs/after-research/`).
+
+### 3. Markdown conventions
+
+- Files use **Markdown / MDX**.
+- Use **sentence case** for page titles and headings (e.g. "How to store your data", not "How To Store Your Data").
+- The first `#` heading and a `sidebar_position` frontmatter value control where a page appears in the sidebar. The sidebar is auto-generated from the folder structure and frontmatter — see [`sidebars.ts`](sidebars.ts).
+- Admonitions (`:::note`, `:::tip`, `:::warning`) are welcome where they help, but use them sparingly.
+- Emojis are allowed where they help readability.
+
+### 4. Commit your change
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/). Start each commit message with a type, an optional scope, and a short description in the imperative mood:
+
+```
+<type>(optional scope): <short description>
+```
+
+Common types:
+
+| Type     | Use for                                        |
+| -------- | ---------------------------------------------- |
+| `docs`   | Changes to the handbook content                |
+| `fix`    | Bug fixes (broken links, typos, factual errors) |
+| `feat`   | New pages or new content sections              |
+| `style`  | Formatting, white-space, visual-only changes   |
+| `chore`  | Maintenance, config, dependencies              |
+
+Examples:
+
+```
+fix(before-research): Correct link to TU/e RDM policy page
+docs(dmp): Clarify data management plan paragraph wording
+feat(fair-clinic): Add FAIR clinics page
+```
+
+### 5. Push and open a pull request
+
+```bash
+git push -u origin HEAD
+```
+
+GitHub will show you a link to open a pull request. Please fill in the [pull request template](.github/pull_request_template.md).
+
+## Report a bug or content error
+
+Spotted a broken link, a typo, or outdated information? Please [open an issue](https://github.com/tue-datastewards/research-data-management-handbook/issues/new/choose) using the **Bug / content report** template. Provide the page URL and a short description of what's wrong.
+
+## Suggest an enhancement
+
+Have an idea for a new page, a new section, or a bigger improvement? Please [open a plain issue](https://github.com/tue-datastewards/research-data-management-handbook/issues/new) and describe what you'd like to see and why it would help the TU/e research community.
+
+## Pull request process
+
+1. Open a PR from your branch (on your fork) into `main`.
+2. Fill in the PR template. **Before/after screenshots are optional** — include them when the change is visual (layout, styling, new images).
+3. Make sure the PR checklist passes:
+   - I previewed the change locally with `npm start`
+   - Links I touched still work (CI runs `check-links` automatically)
+   - I added new pages to the correct folder and set `sidebar_position`
+   - I used Conventional Commits for my commit messages
+4. A maintainer will review your PR. They may ask for changes — that's normal.
+5. Once approved, a maintainer merges it. 🚀
+
+## Recognition
+
+All contributors are listed on the project's [GitHub Contributors page](https://github.com/tue-datastewards/research-data-management-handbook/graphs/contributors). Thank you for being part of it! 💛
+
+## Where to get help
+
+If you get stuck, want to discuss a change before starting, or have a question:
+
+- 📧 Email the TU/e data stewards at **rdmsupport@tue.nl**
+- 📝 [Open an issue](https://github.com/tue-datastewards/research-data-management-handbook/issues/new)
+
+We'll do our best to respond promptly.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the project's license.
+
+> **Note:** The site footer states the handbook content is dedicated to the public domain (CC0), but the `LICENSE` file in the repository is currently MIT. This inconsistency will be reconciled in a follow-up change. For now, contributions are accepted as-is under the existing repository license.


### PR DESCRIPTION
This PR adds the following new files (4) for :
- CONTRIBUTING.md — guide for TU/e researchers & students: dev setup, fork → branch → PR workflow, branch naming (nami/123-fix-broken-link), Conventional Commits, markdown conventions, reporting bugs / suggesting enhancements, recognition, help (rdmsupport@tue.nl).

- CODE_OF_CONDUCT.md — summary of the TU/e Code of Conduct (https://assets.w3.tue.nl/w/fileadmin/content/Our_University/About%20our%20university/Integrity%20and%20social%20safety/CodeofConduct_TUe.pdf) (CORe values, expected/undesirable behaviour, reporting, consequences); full PDF linked as authoritative.

- .github/pull_request_template.md — lightweight PR template: description + optional before/after screenshot table.

- .github/ISSUE_TEMPLATE/bug_content_report.md — bug / content report template: page URL, what's wrong and what you expected, optional screenshot.

Closes #107