### PR TITLE
fix(fair-clinic): Add page description

### DIFF
--- a/docs/learning-resources/fair-clinic/fair-clinic.mdx
+++ b/docs/learning-resources/fair-clinic/fair-clinic.mdx
@@ -1,4 +1,6 @@
 ---
+Title: FAIR Data Clinic
+description: Join our monthly FAIR Data Clinic, a practical session in which we help you making your dataset ready for repository deposit.
 sidebar_position: 4
 ---
 


### PR DESCRIPTION
This PR adds the page description to FAIR Data Clinic. Previously, it was showing the alt text of the image:
<img width="1183" height="447" alt="fair n" src="https://github.com/user-attachments/assets/a7cb0b62-412b-46ad-a817-c7908fb629bc" />

I changed it to:

<img width="624" height="278" alt="image" src="https://github.com/user-attachments/assets/40cd102e-d139-486b-a54c-fb6006f0dbbf" />
