### PR TITLE
Create Glossary & Integrate with CODATA

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 Learn how to manage your research data at TU/e with the Research Data Management Handbook.
 Link to the page: https://tue-datastewards.github.io/research-data-management-handbook/ 
 
+## Glossary
+
+This handbook includes a glossary of research data management terms sourced from the [CODATA Research Data Management Terminology](https://vocabs.ardc.edu.au/show/metacat.2995). Definitions are fetched from the ARDC SPARQL endpoint at build time — no manual setup is required. Each glossary term page also displays a reference badge linking back to the glossary.
+
 ## Local Development
 
 To start a local development server, you need to have [Node.js](https://nodejs.org/) installed.

--- a/docs/after-research/data-preservation/data-preservation.md
+++ b/docs/after-research/data-preservation/data-preservation.md
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 1
+for_glossary: true
+codata_uri: https://terms.codata.org/rdmt/preservation
 ---
 
 # Data Preservation

--- a/docs/after-research/data-repository/data-repository.md
+++ b/docs/after-research/data-repository/data-repository.md
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 3
+for_glossary: true
+codata_uri: https://terms.codata.org/rdmt/repository
 ---
 
 # Data Repository

--- a/docs/before-research/dmp/dmp.mdx
+++ b/docs/before-research/dmp/dmp.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 3
+for_glossary: true
+codata_uri: https://terms.codata.org/rdmt/data-management-plan
 ---
 
 import CreateDMP from "@site/src/components/CreateDMP";

--- a/docs/before-research/reusing-data/reusing-data.md
+++ b/docs/before-research/reusing-data/reusing-data.md
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 2
+for_glossary: true
+codata_uri: https://terms.codata.org/rdmt/re-use
 ---
 
 # Data Reuse

--- a/docs/during-research/data-organization/data-organization.md
+++ b/docs/during-research/data-organization/data-organization.md
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 1
+for_glossary: true
+codata_uri: https://terms.codata.org/rdmt/organisation-of-data
 ---
 
 # Data Organization & Formats

--- a/docs/during-research/docs-and-metadata/docs-and-metadata.md
+++ b/docs/during-research/docs-and-metadata/docs-and-metadata.md
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 2
+for_glossary: true
+codata_uri: https://terms.codata.org/rdmt/metadata
 ---
 
 # Documentation & Metadata

--- a/docs/during-research/research-software/research-software.md
+++ b/docs/during-research/research-software/research-software.md
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 4
+for_glossary: true
+codata_uri: https://terms.codata.org/rdmt/research-software
 ---
 
 # Research Software

--- a/docs/during-research/storage-and-sharing/storage-and-sharing.md
+++ b/docs/during-research/storage-and-sharing/storage-and-sharing.md
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 3
+for_glossary: true
+codata_uri: https://terms.codata.org/rdmt/data-sharing
 ---
 
 # Data Storage & Sharing

--- a/docs/glossary.mdx
+++ b/docs/glossary.mdx
@@ -1,0 +1,11 @@
+---
+slug: /glossary
+title: Glossary
+description: Glossary of terms
+---
+
+import RenderGlossary from "@site/src/components/RenderGlossary/";
+
+# Glossary of Terms
+
+<RenderGlossary />

--- a/docs/intro/FAIR/FAIR.md
+++ b/docs/intro/FAIR/FAIR.md
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 4
+for_glossary: true
+codata_uri: https://terms.codata.org/rdmt/fair-data-principles
 ---
 
 # FAIR Principles

--- a/docs/intro/rdl/rdl.md
+++ b/docs/intro/rdl/rdl.md
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 3
+for_glossary: true
+codata_uri: https://terms.codata.org/rdmt/research-data-lifecycle
 ---
 
 # Research Data Lifecycle

--- a/docs/intro/rdm/rdm.md
+++ b/docs/intro/rdm/rdm.md
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 2
+for_glossary: true
+codata_uri: https://terms.codata.org/rdmt/research-data-management
 ---
 
 # Research Data Management

--- a/docs/intro/research-data/research-data.md
+++ b/docs/intro/research-data/research-data.md
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 1
+for_glossary: true
+codata_uri: https://terms.codata.org/rdmt/research-data
 ---
 
 # Research Data

--- a/docs/privacy/privacy/privacy.md
+++ b/docs/privacy/privacy/privacy.md
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 1
+for_glossary: true
+codata_uri: https://terms.codata.org/rdmt/personal-information-privacy
 ---
 
 # Privacy

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -157,7 +157,10 @@ const config: Config = {
       darkTheme: prismThemes.dracula,
     },
   } satisfies Preset.ThemeConfig,
-  plugins: [require.resolve("docusaurus-lunr-search")],
+  plugins: [
+    require.resolve("docusaurus-lunr-search"),
+    require.resolve("./plugins/generate-glossary"),
+  ],
 }
 
 export default config

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@docusaurus/core": "3.7.0",
+        "@docusaurus/plugin-content-docs": "^3.10.2",
         "@docusaurus/preset-classic": "3.7.0",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
@@ -26,6 +27,21 @@
       },
       "engines": {
         "node": ">=18.0"
+      }
+    },
+    "node_modules/@11ty/gray-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@11ty/gray-matter/-/gray-matter-1.0.0.tgz",
+      "integrity": "sha512-7mJJl+wf1AByoT0PknQiQfOPnVNT4fevGrUBVWO4HXsnYn1aQPyRyrELYrNUFleUBM++KzMKN6QaxHPk0t/6/g==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^4.1.0",
+        "kind-of": "^6.0.3",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=11"
       }
     },
     "node_modules/@algolia/autocomplete-core": {
@@ -1712,7 +1728,9 @@
       }
     },
     "node_modules/@csstools/cascade-layer-name-parser": {
-      "version": "2.0.4",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/cascade-layer-name-parser/-/cascade-layer-name-parser-2.0.5.tgz",
+      "integrity": "sha512-p1ko5eHgV+MgXFVa4STPKpvPxr6ReS8oS2jzTukjR74i5zJNyWO1ZM1m8YKBXnzDKWfBN1ztLYlHxbVemDD88A==",
       "funding": [
         {
           "type": "github",
@@ -1728,12 +1746,14 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3"
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
       }
     },
     "node_modules/@csstools/color-helpers": {
-      "version": "5.0.2",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
       "funding": [
         {
           "type": "github",
@@ -1750,7 +1770,9 @@
       }
     },
     "node_modules/@csstools/css-calc": {
-      "version": "2.1.3",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
       "funding": [
         {
           "type": "github",
@@ -1766,12 +1788,14 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3"
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "3.0.9",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
       "funding": [
         {
           "type": "github",
@@ -1784,19 +1808,21 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@csstools/color-helpers": "^5.0.2",
-        "@csstools/css-calc": "^2.1.3"
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3"
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
       }
     },
     "node_modules/@csstools/css-parser-algorithms": {
-      "version": "3.0.4",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
       "funding": [
         {
           "type": "github",
@@ -1812,11 +1838,13 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@csstools/css-tokenizer": "^3.0.3"
+        "@csstools/css-tokenizer": "^3.0.4"
       }
     },
     "node_modules/@csstools/css-tokenizer": {
-      "version": "3.0.3",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
       "funding": [
         {
           "type": "github",
@@ -1833,7 +1861,9 @@
       }
     },
     "node_modules/@csstools/media-query-list-parser": {
-      "version": "4.0.2",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-4.0.3.tgz",
+      "integrity": "sha512-HAYH7d3TLRHDOUQK4mZKf9k9Ph/m8Akstg66ywKR4SFAigjs3yBiUeZtFxywiTm5moZMAp/5W/ZuFnNXXYLuuQ==",
       "funding": [
         {
           "type": "github",
@@ -1849,12 +1879,43 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3"
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/postcss-alpha-function": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-alpha-function/-/postcss-alpha-function-1.0.1.tgz",
+      "integrity": "sha512-isfLLwksH3yHkFXfCI2Gcaqg7wGGHZZwunoJzEZk0yKYIokgre6hYVFibKL3SYAoR1kBXova8LB+JoO5vZzi9w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/css-color-parser": "^3.1.0",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.1",
+        "@csstools/utilities": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
       }
     },
     "node_modules/@csstools/postcss-cascade-layers": {
-      "version": "5.0.1",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-cascade-layers/-/postcss-cascade-layers-5.0.2.tgz",
+      "integrity": "sha512-nWBE08nhO8uWl6kSAeCx4im7QfVko3zLrtgWZY4/bP87zrSPpSyN/3W3TDqz1jJuH+kbKOHXg5rJnK+ZVYcFFg==",
       "funding": [
         {
           "type": "github",
@@ -1878,7 +1939,9 @@
       }
     },
     "node_modules/@csstools/postcss-color-function": {
-      "version": "4.0.9",
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-color-function/-/postcss-color-function-4.0.12.tgz",
+      "integrity": "sha512-yx3cljQKRaSBc2hfh8rMZFZzChaFgwmO2JfFgFr1vMcF3C/uyy5I4RFIBOIWGq1D+XbKCG789CGkG6zzkLpagA==",
       "funding": [
         {
           "type": "github",
@@ -1891,10 +1954,39 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/css-color-parser": "^3.0.9",
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3",
-        "@csstools/postcss-progressive-custom-properties": "^4.0.1",
+        "@csstools/css-color-parser": "^3.1.0",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.1",
+        "@csstools/utilities": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/postcss-color-function-display-p3-linear": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-color-function-display-p3-linear/-/postcss-color-function-display-p3-linear-1.0.1.tgz",
+      "integrity": "sha512-E5qusdzhlmO1TztYzDIi8XPdPoYOjoTY6HBYBCYSj+Gn4gQRBlvjgPQXzfzuPQqt8EhkC/SzPKObg4Mbn8/xMg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/css-color-parser": "^3.1.0",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.1",
         "@csstools/utilities": "^2.0.0"
       },
       "engines": {
@@ -1905,7 +1997,9 @@
       }
     },
     "node_modules/@csstools/postcss-color-mix-function": {
-      "version": "3.0.9",
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-color-mix-function/-/postcss-color-mix-function-3.0.12.tgz",
+      "integrity": "sha512-4STERZfCP5Jcs13P1U5pTvI9SkgLgfMUMhdXW8IlJWkzOOOqhZIjcNhWtNJZes2nkBDsIKJ0CJtFtuaZ00moag==",
       "funding": [
         {
           "type": "github",
@@ -1918,10 +2012,39 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/css-color-parser": "^3.0.9",
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3",
-        "@csstools/postcss-progressive-custom-properties": "^4.0.1",
+        "@csstools/css-color-parser": "^3.1.0",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.1",
+        "@csstools/utilities": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/postcss-color-mix-variadic-function-arguments": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-color-mix-variadic-function-arguments/-/postcss-color-mix-variadic-function-arguments-1.0.2.tgz",
+      "integrity": "sha512-rM67Gp9lRAkTo+X31DUqMEq+iK+EFqsidfecmhrteErxJZb6tUoJBVQca1Vn1GpDql1s1rD1pKcuYzMsg7Z1KQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/css-color-parser": "^3.1.0",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.1",
         "@csstools/utilities": "^2.0.0"
       },
       "engines": {
@@ -1932,7 +2055,9 @@
       }
     },
     "node_modules/@csstools/postcss-content-alt-text": {
-      "version": "2.0.5",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-content-alt-text/-/postcss-content-alt-text-2.0.8.tgz",
+      "integrity": "sha512-9SfEW9QCxEpTlNMnpSqFaHyzsiRpZ5J5+KqCu1u5/eEJAWsMhzT40qf0FIbeeglEvrGRMdDzAxMIz3wqoGSb+Q==",
       "funding": [
         {
           "type": "github",
@@ -1945,9 +2070,38 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3",
-        "@csstools/postcss-progressive-custom-properties": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.1",
+        "@csstools/utilities": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/postcss-contrast-color-function": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-contrast-color-function/-/postcss-contrast-color-function-2.0.12.tgz",
+      "integrity": "sha512-YbwWckjK3qwKjeYz/CijgcS7WDUCtKTd8ShLztm3/i5dhh4NaqzsbYnhm4bjrpFpnLZ31jVcbK8YL77z3GBPzA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/css-color-parser": "^3.1.0",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.1",
         "@csstools/utilities": "^2.0.0"
       },
       "engines": {
@@ -1958,7 +2112,9 @@
       }
     },
     "node_modules/@csstools/postcss-exponential-functions": {
-      "version": "2.0.8",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-exponential-functions/-/postcss-exponential-functions-2.0.9.tgz",
+      "integrity": "sha512-abg2W/PI3HXwS/CZshSa79kNWNZHdJPMBXeZNyPQFbbj8sKO3jXxOt/wF7juJVjyDTc6JrvaUZYFcSBZBhaxjw==",
       "funding": [
         {
           "type": "github",
@@ -1971,9 +2127,9 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/css-calc": "^2.1.3",
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3"
+        "@csstools/css-calc": "^2.1.4",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
       },
       "engines": {
         "node": ">=18"
@@ -2007,7 +2163,9 @@
       }
     },
     "node_modules/@csstools/postcss-gamut-mapping": {
-      "version": "2.0.9",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-gamut-mapping/-/postcss-gamut-mapping-2.0.11.tgz",
+      "integrity": "sha512-fCpCUgZNE2piVJKC76zFsgVW1apF6dpYsqGyH8SIeCcM4pTEsRTWTLCaJIMKFEundsCKwY1rwfhtrio04RJ4Dw==",
       "funding": [
         {
           "type": "github",
@@ -2020,9 +2178,9 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/css-color-parser": "^3.0.9",
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3"
+        "@csstools/css-color-parser": "^3.1.0",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
       },
       "engines": {
         "node": ">=18"
@@ -2032,7 +2190,9 @@
       }
     },
     "node_modules/@csstools/postcss-gradients-interpolation-method": {
-      "version": "5.0.9",
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-gradients-interpolation-method/-/postcss-gradients-interpolation-method-5.0.12.tgz",
+      "integrity": "sha512-jugzjwkUY0wtNrZlFeyXzimUL3hN4xMvoPnIXxoZqxDvjZRiSh+itgHcVUWzJ2VwD/VAMEgCLvtaJHX+4Vj3Ow==",
       "funding": [
         {
           "type": "github",
@@ -2045,10 +2205,10 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/css-color-parser": "^3.0.9",
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3",
-        "@csstools/postcss-progressive-custom-properties": "^4.0.1",
+        "@csstools/css-color-parser": "^3.1.0",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.1",
         "@csstools/utilities": "^2.0.0"
       },
       "engines": {
@@ -2059,7 +2219,9 @@
       }
     },
     "node_modules/@csstools/postcss-hwb-function": {
-      "version": "4.0.9",
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-hwb-function/-/postcss-hwb-function-4.0.12.tgz",
+      "integrity": "sha512-mL/+88Z53KrE4JdePYFJAQWFrcADEqsLprExCM04GDNgHIztwFzj0Mbhd/yxMBngq0NIlz58VVxjt5abNs1VhA==",
       "funding": [
         {
           "type": "github",
@@ -2072,10 +2234,10 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/css-color-parser": "^3.0.9",
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3",
-        "@csstools/postcss-progressive-custom-properties": "^4.0.1",
+        "@csstools/css-color-parser": "^3.1.0",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.1",
         "@csstools/utilities": "^2.0.0"
       },
       "engines": {
@@ -2086,7 +2248,9 @@
       }
     },
     "node_modules/@csstools/postcss-ic-unit": {
-      "version": "4.0.1",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-ic-unit/-/postcss-ic-unit-4.0.4.tgz",
+      "integrity": "sha512-yQ4VmossuOAql65sCPppVO1yfb7hDscf4GseF0VCA/DTDaBc0Wtf8MTqVPfjGYlT5+2buokG0Gp7y0atYZpwjg==",
       "funding": [
         {
           "type": "github",
@@ -2099,7 +2263,7 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/postcss-progressive-custom-properties": "^4.0.1",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.1",
         "@csstools/utilities": "^2.0.0",
         "postcss-value-parser": "^4.2.0"
       },
@@ -2131,7 +2295,9 @@
       }
     },
     "node_modules/@csstools/postcss-is-pseudo-class": {
-      "version": "5.0.1",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-is-pseudo-class/-/postcss-is-pseudo-class-5.0.3.tgz",
+      "integrity": "sha512-jS/TY4SpG4gszAtIg7Qnf3AS2pjcUM5SzxpApOrlndMeGhIbaTzWBzzP/IApXoNWEW7OhcjkRT48jnAUIFXhAQ==",
       "funding": [
         {
           "type": "github",
@@ -2155,7 +2321,9 @@
       }
     },
     "node_modules/@csstools/postcss-light-dark-function": {
-      "version": "2.0.8",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-light-dark-function/-/postcss-light-dark-function-2.0.11.tgz",
+      "integrity": "sha512-fNJcKXJdPM3Lyrbmgw2OBbaioU7yuKZtiXClf4sGdQttitijYlZMD5K7HrC/eF83VRWRrYq6OZ0Lx92leV2LFA==",
       "funding": [
         {
           "type": "github",
@@ -2168,9 +2336,9 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3",
-        "@csstools/postcss-progressive-custom-properties": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.1",
         "@csstools/utilities": "^2.0.0"
       },
       "engines": {
@@ -2264,7 +2432,9 @@
       }
     },
     "node_modules/@csstools/postcss-logical-viewport-units": {
-      "version": "3.0.3",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-logical-viewport-units/-/postcss-logical-viewport-units-3.0.4.tgz",
+      "integrity": "sha512-q+eHV1haXA4w9xBwZLKjVKAWn3W2CMqmpNpZUk5kRprvSiBEGMgrNH3/sJZ8UA3JgyHaOt3jwT9uFa4wLX4EqQ==",
       "funding": [
         {
           "type": "github",
@@ -2277,7 +2447,7 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/css-tokenizer": "^3.0.3",
+        "@csstools/css-tokenizer": "^3.0.4",
         "@csstools/utilities": "^2.0.0"
       },
       "engines": {
@@ -2288,7 +2458,9 @@
       }
     },
     "node_modules/@csstools/postcss-media-minmax": {
-      "version": "2.0.8",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-media-minmax/-/postcss-media-minmax-2.0.9.tgz",
+      "integrity": "sha512-af9Qw3uS3JhYLnCbqtZ9crTvvkR+0Se+bBqSr7ykAnl9yKhk6895z9rf+2F4dClIDJWxgn0iZZ1PSdkhrbs2ig==",
       "funding": [
         {
           "type": "github",
@@ -2301,10 +2473,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@csstools/css-calc": "^2.1.3",
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3",
-        "@csstools/media-query-list-parser": "^4.0.2"
+        "@csstools/css-calc": "^2.1.4",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "@csstools/media-query-list-parser": "^4.0.3"
       },
       "engines": {
         "node": ">=18"
@@ -2314,7 +2486,9 @@
       }
     },
     "node_modules/@csstools/postcss-media-queries-aspect-ratio-number-values": {
-      "version": "3.0.4",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-media-queries-aspect-ratio-number-values/-/postcss-media-queries-aspect-ratio-number-values-3.0.5.tgz",
+      "integrity": "sha512-zhAe31xaaXOY2Px8IYfoVTB3wglbJUVigGphFLj6exb7cjZRH9A6adyE22XfFK3P2PzwRk0VDeTJmaxpluyrDg==",
       "funding": [
         {
           "type": "github",
@@ -2327,9 +2501,9 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3",
-        "@csstools/media-query-list-parser": "^4.0.2"
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "@csstools/media-query-list-parser": "^4.0.3"
       },
       "engines": {
         "node": ">=18"
@@ -2363,7 +2537,9 @@
       }
     },
     "node_modules/@csstools/postcss-normalize-display-values": {
-      "version": "4.0.0",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-normalize-display-values/-/postcss-normalize-display-values-4.0.1.tgz",
+      "integrity": "sha512-TQUGBuRvxdc7TgNSTevYqrL8oItxiwPDixk20qCB5me/W8uF7BPbhRrAvFuhEoywQp/woRsUZ6SJ+sU5idZAIA==",
       "funding": [
         {
           "type": "github",
@@ -2386,7 +2562,9 @@
       }
     },
     "node_modules/@csstools/postcss-oklab-function": {
-      "version": "4.0.9",
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-oklab-function/-/postcss-oklab-function-4.0.12.tgz",
+      "integrity": "sha512-HhlSmnE1NKBhXsTnNGjxvhryKtO7tJd1w42DKOGFD6jSHtYOrsJTQDKPMwvOfrzUAk8t7GcpIfRyM7ssqHpFjg==",
       "funding": [
         {
           "type": "github",
@@ -2399,10 +2577,10 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/css-color-parser": "^3.0.9",
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3",
-        "@csstools/postcss-progressive-custom-properties": "^4.0.1",
+        "@csstools/css-color-parser": "^3.1.0",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.1",
         "@csstools/utilities": "^2.0.0"
       },
       "engines": {
@@ -2412,8 +2590,32 @@
         "postcss": "^8.4"
       }
     },
+    "node_modules/@csstools/postcss-position-area-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-position-area-property/-/postcss-position-area-property-1.0.0.tgz",
+      "integrity": "sha512-fUP6KR8qV2NuUZV3Cw8itx0Ep90aRjAZxAEzC3vrl6yjFv+pFsQbR18UuQctEKmA72K9O27CoYiKEgXxkqjg8Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
     "node_modules/@csstools/postcss-progressive-custom-properties": {
-      "version": "4.0.1",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-progressive-custom-properties/-/postcss-progressive-custom-properties-4.2.1.tgz",
+      "integrity": "sha512-uPiiXf7IEKtUQXsxu6uWtOlRMXd2QWWy5fhxHDnPdXKCQckPP3E34ZgDoZ62r2iT+UOgWsSbM4NvHE5m3mAEdw==",
       "funding": [
         {
           "type": "github",
@@ -2435,8 +2637,10 @@
         "postcss": "^8.4"
       }
     },
-    "node_modules/@csstools/postcss-random-function": {
-      "version": "2.0.0",
+    "node_modules/@csstools/postcss-property-rule-prelude-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-property-rule-prelude-list/-/postcss-property-rule-prelude-list-1.0.0.tgz",
+      "integrity": "sha512-IxuQjUXq19fobgmSSvUDO7fVwijDJaZMvWQugxfEUxmjBeDCVaDuMpsZ31MsTm5xbnhA+ElDi0+rQ7sQQGisFA==",
       "funding": [
         {
           "type": "github",
@@ -2449,9 +2653,35 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/css-calc": "^2.1.3",
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3"
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/postcss-random-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-random-function/-/postcss-random-function-2.0.1.tgz",
+      "integrity": "sha512-q+FQaNiRBhnoSNo+GzqGOIBKoHQ43lYz0ICrV+UudfWnEF6ksS6DsBIJSISKQT2Bvu3g4k6r7t0zYrk5pDlo8w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.4",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
       },
       "engines": {
         "node": ">=18"
@@ -2461,7 +2691,9 @@
       }
     },
     "node_modules/@csstools/postcss-relative-color-syntax": {
-      "version": "3.0.9",
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-relative-color-syntax/-/postcss-relative-color-syntax-3.0.12.tgz",
+      "integrity": "sha512-0RLIeONxu/mtxRtf3o41Lq2ghLimw0w9ByLWnnEVuy89exmEEq8bynveBxNW3nyHqLAFEeNtVEmC1QK9MZ8Huw==",
       "funding": [
         {
           "type": "github",
@@ -2474,10 +2706,10 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/css-color-parser": "^3.0.9",
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3",
-        "@csstools/postcss-progressive-custom-properties": "^4.0.1",
+        "@csstools/css-color-parser": "^3.1.0",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.1",
         "@csstools/utilities": "^2.0.0"
       },
       "engines": {
@@ -2511,7 +2743,9 @@
       }
     },
     "node_modules/@csstools/postcss-sign-functions": {
-      "version": "1.1.3",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-sign-functions/-/postcss-sign-functions-1.1.4.tgz",
+      "integrity": "sha512-P97h1XqRPcfcJndFdG95Gv/6ZzxUBBISem0IDqPZ7WMvc/wlO+yU0c5D/OCpZ5TJoTt63Ok3knGk64N+o6L2Pg==",
       "funding": [
         {
           "type": "github",
@@ -2524,9 +2758,9 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/css-calc": "^2.1.3",
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3"
+        "@csstools/css-calc": "^2.1.4",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
       },
       "engines": {
         "node": ">=18"
@@ -2536,7 +2770,9 @@
       }
     },
     "node_modules/@csstools/postcss-stepped-value-functions": {
-      "version": "4.0.8",
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-stepped-value-functions/-/postcss-stepped-value-functions-4.0.9.tgz",
+      "integrity": "sha512-h9btycWrsex4dNLeQfyU3y3w40LMQooJWFMm/SK9lrKguHDcFl4VMkncKKoXi2z5rM9YGWbUQABI8BT2UydIcA==",
       "funding": [
         {
           "type": "github",
@@ -2549,9 +2785,60 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/css-calc": "^2.1.3",
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3"
+        "@csstools/css-calc": "^2.1.4",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/postcss-syntax-descriptor-syntax-production": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-syntax-descriptor-syntax-production/-/postcss-syntax-descriptor-syntax-production-1.0.1.tgz",
+      "integrity": "sha512-GneqQWefjM//f4hJ/Kbox0C6f2T7+pi4/fqTqOFGTL3EjnvOReTqO1qUQ30CaUjkwjYq9qZ41hzarrAxCc4gow==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/postcss-system-ui-font-family": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-system-ui-font-family/-/postcss-system-ui-font-family-1.0.0.tgz",
+      "integrity": "sha512-s3xdBvfWYfoPSBsikDXbuorcMG1nN1M6GdU0qBsGfcmNR0A/qhloQZpTxjA3Xsyrk1VJvwb2pOfiOT3at/DuIQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
       },
       "engines": {
         "node": ">=18"
@@ -2561,7 +2848,9 @@
       }
     },
     "node_modules/@csstools/postcss-text-decoration-shorthand": {
-      "version": "4.0.2",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-text-decoration-shorthand/-/postcss-text-decoration-shorthand-4.0.3.tgz",
+      "integrity": "sha512-KSkGgZfx0kQjRIYnpsD7X2Om9BUXX/Kii77VBifQW9Ih929hK0KNjVngHDH0bFB9GmfWcR9vJYJJRvw/NQjkrA==",
       "funding": [
         {
           "type": "github",
@@ -2574,7 +2863,7 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/color-helpers": "^5.0.2",
+        "@csstools/color-helpers": "^5.1.0",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
@@ -2585,7 +2874,9 @@
       }
     },
     "node_modules/@csstools/postcss-trigonometric-functions": {
-      "version": "4.0.8",
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-trigonometric-functions/-/postcss-trigonometric-functions-4.0.9.tgz",
+      "integrity": "sha512-Hnh5zJUdpNrJqK9v1/E3BbrQhaDTj5YiX7P61TOvUhoDHnUmsNNxcDAgkQ32RrcWx9GVUvfUNPcUkn8R3vIX6A==",
       "funding": [
         {
           "type": "github",
@@ -2598,9 +2889,9 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/css-calc": "^2.1.3",
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3"
+        "@csstools/css-calc": "^2.1.4",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
       },
       "engines": {
         "node": ">=18"
@@ -2630,7 +2921,9 @@
       }
     },
     "node_modules/@csstools/selector-resolve-nested": {
-      "version": "3.0.0",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-3.1.0.tgz",
+      "integrity": "sha512-mf1LEW0tJLKfWyvn5KdDrhpxHyuxpbNwTIwOYLIvsTffeyOf85j5oIzfG0yosxDgx/sswlqBnESYUcQH0vgZ0g==",
       "funding": [
         {
           "type": "github",
@@ -2651,6 +2944,8 @@
     },
     "node_modules/@csstools/selector-specificity": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz",
+      "integrity": "sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==",
       "funding": [
         {
           "type": "github",
@@ -2978,33 +3273,697 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "3.7.0",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.10.2.tgz",
+      "integrity": "sha512-Sqwl4FPoZBDrlY8I2VU2H8O0M91CHp9T8ToMSkTZmjvHCif+1laqfXi6sTk8IfyVS/trN5yNjcWd1bFsGB6W5Q==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.7.0",
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/mdx-loader": "3.7.0",
-        "@docusaurus/module-type-aliases": "3.7.0",
-        "@docusaurus/theme-common": "3.7.0",
-        "@docusaurus/types": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "@docusaurus/utils-validation": "3.7.0",
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/logger": "3.10.2",
+        "@docusaurus/mdx-loader": "3.10.2",
+        "@docusaurus/module-type-aliases": "3.10.2",
+        "@docusaurus/theme-common": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-common": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "@types/react-router-config": "^5.0.7",
         "combine-promises": "^1.1.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",
+        "schema-dts": "^1.1.2",
         "tslib": "^2.6.0",
         "utility-types": "^3.10.0",
         "webpack": "^5.88.1"
       },
       "engines": {
-        "node": ">=18.0"
+        "node": ">=20.0"
       },
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/babel": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.10.2.tgz",
+      "integrity": "sha512-aJ1hpGyvfkte3dDAfNbWM4biW4yWZBVz7TIGLZP+v+tWOBgxX3e0N5ZIXHIvmfNNXTI77pcHUx3KmtOk05Ze3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.25.9",
+        "@babel/generator": "^7.25.9",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+        "@babel/plugin-transform-runtime": "^7.25.9",
+        "@babel/preset-env": "^7.25.9",
+        "@babel/preset-react": "^7.25.9",
+        "@babel/preset-typescript": "^7.25.9",
+        "@babel/runtime": "^7.25.9",
+        "@babel/traverse": "^7.25.9",
+        "@docusaurus/logger": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "babel-plugin-dynamic-import-node": "^2.3.3",
+        "fs-extra": "^11.1.1",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/bundler": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.10.2.tgz",
+      "integrity": "sha512-i0ZNcy0f0WhaOlYVgzLsWhIoEXO9kS3HRoKPtgE6vQtZUq7arKZaYdNBudr3mqCmd+TyOkwtwfHgs1ENj07r5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.25.9",
+        "@docusaurus/babel": "3.10.2",
+        "@docusaurus/cssnano-preset": "3.10.2",
+        "@docusaurus/logger": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "babel-loader": "^9.2.1",
+        "clean-css": "^5.3.3",
+        "copy-webpack-plugin": "^11.0.0",
+        "css-loader": "^6.11.0",
+        "css-minimizer-webpack-plugin": "^5.0.1",
+        "cssnano": "^6.1.2",
+        "file-loader": "^6.2.0",
+        "html-minifier-terser": "^7.2.0",
+        "mini-css-extract-plugin": "^2.9.2",
+        "null-loader": "^4.0.1",
+        "postcss": "^8.5.4",
+        "postcss-loader": "^7.3.4",
+        "postcss-preset-env": "^10.2.1",
+        "terser-webpack-plugin": "^5.3.9",
+        "tslib": "^2.6.0",
+        "url-loader": "^4.1.1",
+        "webpack": "^5.95.0",
+        "webpackbar": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20.0"
+      },
+      "peerDependencies": {
+        "@docusaurus/faster": "*"
+      },
+      "peerDependenciesMeta": {
+        "@docusaurus/faster": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/core": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.10.2.tgz",
+      "integrity": "sha512-EYByj6nk+aD9KeVxV6Hmo2/nAAT79P21Y82ycTBOBtrmqilloIbIEhgL2/8Xpt2Jz/pgNqHAwyusOGwmbKeJmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/babel": "3.10.2",
+        "@docusaurus/bundler": "3.10.2",
+        "@docusaurus/logger": "3.10.2",
+        "@docusaurus/mdx-loader": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-common": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
+        "boxen": "^6.2.1",
+        "chalk": "^4.1.2",
+        "chokidar": "^3.5.3",
+        "cli-table3": "^0.6.3",
+        "combine-promises": "^1.1.0",
+        "commander": "^5.1.0",
+        "core-js": "^3.31.1",
+        "detect-port": "^2.1.0",
+        "escape-html": "^1.0.3",
+        "eta": "^2.2.0",
+        "eval": "^0.1.8",
+        "execa": "^5.1.1",
+        "fs-extra": "^11.1.1",
+        "html-tags": "^3.3.1",
+        "html-webpack-plugin": "^5.6.0",
+        "leven": "^3.1.0",
+        "lodash": "^4.17.21",
+        "open": "^8.4.0",
+        "p-map": "^4.0.0",
+        "prompts": "^2.4.2",
+        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
+        "react-loadable-ssr-addon-v5-slorber": "^1.0.3",
+        "react-router": "^5.3.4",
+        "react-router-config": "^5.1.1",
+        "react-router-dom": "^5.3.4",
+        "semver": "^7.5.4",
+        "serve-handler": "^6.1.7",
+        "tinypool": "^1.0.2",
+        "tslib": "^2.6.0",
+        "update-notifier": "^6.0.2",
+        "webpack": "^5.95.0",
+        "webpack-bundle-analyzer": "^4.10.2",
+        "webpack-dev-server": "^5.2.2",
+        "webpack-merge": "^6.0.1"
+      },
+      "bin": {
+        "docusaurus": "bin/docusaurus.mjs"
+      },
+      "engines": {
+        "node": ">=20.0"
+      },
+      "peerDependencies": {
+        "@docusaurus/faster": "*",
+        "@mdx-js/react": "^3.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@docusaurus/faster": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/core/node_modules/webpack-merge": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
+      "integrity": "sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==",
+      "license": "MIT",
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "flat": "^5.0.2",
+        "wildcard": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/cssnano-preset": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.10.2.tgz",
+      "integrity": "sha512-4gCnHRbJLTloiwfvFAa92tgb2gI4KYhvjfQVYnEaiMO/EgvWfCo1LwytHXen+1oZAN0VAlS0JAPxp3MsvKDa3A==",
+      "license": "MIT",
+      "dependencies": {
+        "cssnano-preset-advanced": "^6.1.2",
+        "postcss": "^8.5.4",
+        "postcss-sort-media-queries": "^5.2.0",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/logger": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.10.2.tgz",
+      "integrity": "sha512-gSEwqtPfCAnC3ZSJY6xL7tcIfgg0vFD39jbv93eakuweyvO2864xR0K+kmKwBhkTCtWRNjuGGnb5rdmkD/ndqw==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/mdx-loader": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.10.2.tgz",
+      "integrity": "sha512-9Fd4V/SFjfrVQ0JH5EN0+iPWyFunvTeQE3gfyFeetqPaXMP0OylIjOw16dCuXG4NZJrYdBqwzjh18/h3gRi47w==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/logger": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
+        "@mdx-js/mdx": "^3.0.0",
+        "@slorber/remark-comment": "^1.0.0",
+        "escape-html": "^1.0.3",
+        "estree-util-value-to-estree": "^3.0.1",
+        "file-loader": "^6.2.0",
+        "fs-extra": "^11.1.1",
+        "image-size": "^2.0.2",
+        "mdast-util-mdx": "^3.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "rehype-raw": "^7.0.0",
+        "remark-directive": "^3.0.0",
+        "remark-emoji": "^4.0.0",
+        "remark-frontmatter": "^5.0.0",
+        "remark-gfm": "^4.0.0",
+        "stringify-object": "^3.3.0",
+        "tslib": "^2.6.0",
+        "unified": "^11.0.3",
+        "unist-util-visit": "^5.0.0",
+        "url-loader": "^4.1.1",
+        "vfile": "^6.0.1",
+        "webpack": "^5.88.1"
+      },
+      "engines": {
+        "node": ">=20.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/module-type-aliases": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.10.2.tgz",
+      "integrity": "sha512-h/I5e4jaAhDHW4vaLENi1i2hnOEnXY1t9R+nnRTbgUl7ymVRzN/HF7dDfj8rKYGj8gfIge+Ef+iYRAMtbGvsrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/types": "3.10.2",
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router-config": "*",
+        "@types/react-router-dom": "*",
+        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/theme-common": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.10.2.tgz",
+      "integrity": "sha512-R9b/vMpK1yye6hNZTA6x/ivRv+at6GhxnXcxkpzCGzO1R1RwiquqiFg2wMFh6aqlJTpWRFKpFD2TzCDQcyOU0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/mdx-loader": "3.10.2",
+        "@docusaurus/module-type-aliases": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-common": "3.10.2",
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router-config": "*",
+        "clsx": "^2.0.0",
+        "parse-numeric-range": "^1.3.0",
+        "prism-react-renderer": "^2.3.0",
+        "tslib": "^2.6.0",
+        "utility-types": "^3.10.0"
+      },
+      "engines": {
+        "node": ">=20.0"
+      },
+      "peerDependencies": {
+        "@docusaurus/plugin-content-docs": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/types": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.2.tgz",
+      "integrity": "sha512-B6rvfwIFSapUqUJjMriZswX13K8l5Z7AcmVE6uTEJpYddQieSTR12DsGaFtcZAIDsQd4p+0WTl0Vc6jmZK0Trw==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdx-js/mdx": "^3.0.0",
+        "@types/history": "^4.7.11",
+        "@types/mdast": "^4.0.2",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.9.2",
+        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.95.0",
+        "webpack-merge": "^5.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/utils": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.10.2.tgz",
+      "integrity": "sha512-xx0W3eav2uW1NRIpuHJWNwLTC15xPNjU4Uxi9NSnd3swYC96BE3vFiT93SD8s24kmAAWNwgZwfZ2fghGZ01Lcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@11ty/gray-matter": "^1.0.0",
+        "@docusaurus/logger": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils-common": "3.10.2",
+        "escape-string-regexp": "^4.0.0",
+        "execa": "^5.1.1",
+        "file-loader": "^6.2.0",
+        "fs-extra": "^11.1.1",
+        "github-slugger": "^1.5.0",
+        "globby": "^11.1.0",
+        "jiti": "^1.20.0",
+        "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
+        "micromatch": "^4.0.5",
+        "p-queue": "^6.6.2",
+        "prompts": "^2.4.2",
+        "resolve-pathname": "^3.0.0",
+        "tslib": "^2.6.0",
+        "url-loader": "^4.1.1",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.88.1"
+      },
+      "engines": {
+        "node": ">=20.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/utils-common": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.10.2.tgz",
+      "integrity": "sha512-x3Dz6jv6iQKBNjBmVTu8p57abMp/VNTUgKBMgRVXJc5444orBTsArv0+cdfrXTiz/VMmHfDRVkPbL7GH2B7T7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/types": "3.10.2",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/utils-validation": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.10.2.tgz",
+      "integrity": "sha512-sn8unbDfUL585NtR3cwHefPicOyaHvPaX7VD0aOg/siIxUBoKyKKaGEqzJZDS64mM43TnxurkYDtmB1wsJlZsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/logger": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-common": "3.10.2",
+        "fs-extra": "^11.2.0",
+        "joi": "^17.9.2",
+        "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-docs/node_modules/@types/express-serve-static-core": {
+      "version": "4.19.9",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.9.tgz",
+      "integrity": "sha512-QP2ESEe/ImWY0HDwNAnK9PvEffUyhLTnWkk7KXzHfyeWAnlrDe1fN77bXl6ia8KT3wPlmA7t9/VPRpnf4Ex9sg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-docs/node_modules/@types/retry": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
+      "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
+      "license": "MIT"
+    },
+    "node_modules/@docusaurus/plugin-content-docs/node_modules/address": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/address/-/address-2.0.3.tgz",
+      "integrity": "sha512-XNAb/a6TCqou+TufU8/u11HCu9x1gYvOoxLwtlXgIqmkrYQADVv6ljyW2zwiPhHz9R1gItAWpuDrdJMmrOBFEA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-docs/node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-docs/node_modules/detect-port": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-2.1.0.tgz",
+      "integrity": "sha512-epZuWb/6Q62L+nDHJc/hQAqf8pylsqgk3BpZXVBx1CDnr3nkrVNn73Uu1rXcFzkNcc+hkP3whuOg7JZYaQB65Q==",
+      "license": "MIT",
+      "dependencies": {
+        "address": "^2.0.1"
+      },
+      "bin": {
+        "detect": "dist/commonjs/bin/detect-port.js",
+        "detect-port": "dist/commonjs/bin/detect-port.js"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-docs/node_modules/image-size": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
+      "integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==",
+      "license": "MIT",
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=16.x"
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-docs/node_modules/ipaddr.js": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
+      "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-docs/node_modules/memfs": {
+      "version": "4.64.0",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.64.0.tgz",
+      "integrity": "sha512-Kw72fgY7Wn+sD8KmtNWSafl1dz0UvAsE/PHs3YVfLiaZuA3HxNm9sRLqAu0ATiBGJvME1PxZXbBZPv5GycDeAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-core": "4.64.0",
+        "@jsonjoy.com/fs-fsa": "4.64.0",
+        "@jsonjoy.com/fs-node": "4.64.0",
+        "@jsonjoy.com/fs-node-builtins": "4.64.0",
+        "@jsonjoy.com/fs-node-to-fsa": "4.64.0",
+        "@jsonjoy.com/fs-node-utils": "4.64.0",
+        "@jsonjoy.com/fs-print": "4.64.0",
+        "@jsonjoy.com/fs-snapshot": "4.64.0",
+        "@jsonjoy.com/json-pack": "^1.11.0",
+        "@jsonjoy.com/util": "^1.9.0",
+        "glob-to-regex.js": "^1.0.1",
+        "thingies": "^2.5.0",
+        "tree-dump": "^1.0.3",
+        "tslib": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-docs/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-docs/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-docs/node_modules/p-retry": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-6.2.1.tgz",
+      "integrity": "sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.2",
+        "is-network-error": "^1.0.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-docs/node_modules/selfsigned": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-5.5.0.tgz",
+      "integrity": "sha512-ftnu3TW4+3eBfLRFnDEkzGxSF/10BJBkaLJuBHZX0kiPS7bRdlpZGu6YGt4KngMkdTwJE6MbjavFpqHvqVt+Ew==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/x509": "^1.14.2",
+        "pkijs": "^3.3.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-docs/node_modules/webpack-dev-middleware": {
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-7.4.5.tgz",
+      "integrity": "sha512-uxQ6YqGdE4hgDKNf7hUiPXOdtkXvBJXrfEGYSx7P7LC8hnUYGK70X6xQXUvXeNyBDDcsiQXpG2m3G9vxowaEuA==",
+      "license": "MIT",
+      "dependencies": {
+        "colorette": "^2.0.10",
+        "memfs": "^4.43.1",
+        "mime-types": "^3.0.1",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "schema-utils": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 18.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-docs/node_modules/webpack-dev-server": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.6.tgz",
+      "integrity": "sha512-HNLRmamRvVavZQ+avceZifmv8hmdUjg43t6MI4SqJDwFdW7RPQwH5vzGhDRZSX59SgfbeHhLnq3g+uooWo7pVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/bonjour": "^3.5.13",
+        "@types/connect-history-api-fallback": "^1.5.4",
+        "@types/express": "^4.17.25",
+        "@types/express-serve-static-core": "^4.17.21",
+        "@types/serve-index": "^1.9.4",
+        "@types/serve-static": "^1.15.5",
+        "@types/sockjs": "^0.3.36",
+        "@types/ws": "^8.5.10",
+        "ansi-html-community": "^0.0.8",
+        "bonjour-service": "^1.2.1",
+        "chokidar": "^3.6.0",
+        "colorette": "^2.0.10",
+        "compression": "^1.8.1",
+        "connect-history-api-fallback": "^2.0.0",
+        "express": "^4.22.1",
+        "graceful-fs": "^4.2.6",
+        "http-proxy-middleware": "^2.0.9",
+        "ipaddr.js": "^2.1.0",
+        "launch-editor": "^2.14.1",
+        "open": "^10.0.3",
+        "p-retry": "^6.2.0",
+        "schema-utils": "^4.2.0",
+        "selfsigned": "^5.5.0",
+        "serve-index": "^1.9.1",
+        "sockjs": "^0.3.24",
+        "spdy": "^4.0.2",
+        "webpack-dev-middleware": "^7.4.2",
+        "ws": "^8.18.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">= 18.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "webpack": {
+          "optional": true
+        },
+        "webpack-cli": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-docs/node_modules/webpack-dev-server/node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-docs/node_modules/webpackbar": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webpackbar/-/webpackbar-7.0.0.tgz",
+      "integrity": "sha512-aS9soqSO2iCHgqHoCrj4LbfGQUboDCYJPSFOAchEK+9psIjNrfSWW4Y0YEz67MKURNvMmfo0ycOg9d/+OOf9/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansis": "^3.2.0",
+        "consola": "^3.2.3",
+        "pretty-time": "^1.1.0",
+        "std-env": "^3.7.0"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "peerDependencies": {
+        "@rspack/core": "*",
+        "webpack": "3 || 4 || 5"
+      },
+      "peerDependenciesMeta": {
+        "@rspack/core": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-docs/node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/@docusaurus/plugin-content-pages": {
@@ -3169,6 +4128,38 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/plugin-content-docs": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.7.0.tgz",
+      "integrity": "sha512-GXg5V7kC9FZE4FkUZA8oo/NrlRb06UwuICzI6tcbzj0+TVgjq/mpUXXzSgKzMS82YByi4dY2Q808njcBCyy6tQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.7.0",
+        "@docusaurus/logger": "3.7.0",
+        "@docusaurus/mdx-loader": "3.7.0",
+        "@docusaurus/module-type-aliases": "3.7.0",
+        "@docusaurus/theme-common": "3.7.0",
+        "@docusaurus/types": "3.7.0",
+        "@docusaurus/utils": "3.7.0",
+        "@docusaurus/utils-common": "3.7.0",
+        "@docusaurus/utils-validation": "3.7.0",
+        "@types/react-router-config": "^5.0.7",
+        "combine-promises": "^1.1.0",
+        "fs-extra": "^11.1.1",
+        "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
+        "tslib": "^2.6.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.88.1"
+      },
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@docusaurus/theme-classic": {
       "version": "3.7.0",
       "license": "MIT",
@@ -3199,6 +4190,38 @@
         "rtlcss": "^4.1.0",
         "tslib": "^2.6.0",
         "utility-types": "^3.10.0"
+      },
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/plugin-content-docs": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.7.0.tgz",
+      "integrity": "sha512-GXg5V7kC9FZE4FkUZA8oo/NrlRb06UwuICzI6tcbzj0+TVgjq/mpUXXzSgKzMS82YByi4dY2Q808njcBCyy6tQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.7.0",
+        "@docusaurus/logger": "3.7.0",
+        "@docusaurus/mdx-loader": "3.7.0",
+        "@docusaurus/module-type-aliases": "3.7.0",
+        "@docusaurus/theme-common": "3.7.0",
+        "@docusaurus/types": "3.7.0",
+        "@docusaurus/utils": "3.7.0",
+        "@docusaurus/utils-common": "3.7.0",
+        "@docusaurus/utils-validation": "3.7.0",
+        "@types/react-router-config": "^5.0.7",
+        "combine-promises": "^1.1.0",
+        "fs-extra": "^11.1.1",
+        "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
+        "tslib": "^2.6.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.88.1"
       },
       "engines": {
         "node": ">=18.0"
@@ -3254,6 +4277,38 @@
         "lodash": "^4.17.21",
         "tslib": "^2.6.0",
         "utility-types": "^3.10.0"
+      },
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@docusaurus/theme-search-algolia/node_modules/@docusaurus/plugin-content-docs": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.7.0.tgz",
+      "integrity": "sha512-GXg5V7kC9FZE4FkUZA8oo/NrlRb06UwuICzI6tcbzj0+TVgjq/mpUXXzSgKzMS82YByi4dY2Q808njcBCyy6tQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.7.0",
+        "@docusaurus/logger": "3.7.0",
+        "@docusaurus/mdx-loader": "3.7.0",
+        "@docusaurus/module-type-aliases": "3.7.0",
+        "@docusaurus/theme-common": "3.7.0",
+        "@docusaurus/types": "3.7.0",
+        "@docusaurus/utils": "3.7.0",
+        "@docusaurus/utils-common": "3.7.0",
+        "@docusaurus/utils-validation": "3.7.0",
+        "@types/react-router-config": "^5.0.7",
+        "combine-promises": "^1.1.0",
+        "fs-extra": "^11.1.1",
+        "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
+        "tslib": "^2.6.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.88.1"
       },
       "engines": {
         "node": ">=18.0"
@@ -3437,6 +4492,416 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@jsonjoy.com/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/buffers": {
+      "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-17.67.0.tgz",
+      "integrity": "sha512-tfExRpYxBvi32vPs9ZHaTjSP4fHAfzSmcahOfNxtvGHcyJel+aibkPlGeBB+7AoC6hL7lXIE++8okecBxx7lcw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/codegen": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-1.0.0.tgz",
+      "integrity": "sha512-E8Oy+08cmCf0EK/NMxpaJZmOxPqM+6iSe2S4nlSBrPZOORoDJILxtbSUEDKQyTamm/BVAhIGllOBNU79/dwf0g==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-core": {
+      "version": "4.64.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.64.0.tgz",
+      "integrity": "sha512-zs2TAq7Six5jgMuoMNjpspAvOP3mhtgq/k1UyQodEzCtQi/N83y2/y+zcvnZSGp/Rxq96DBN+bValOBQAyn/ew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-node-builtins": "4.64.0",
+        "@jsonjoy.com/fs-node-utils": "4.64.0",
+        "thingies": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-fsa": {
+      "version": "4.64.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.64.0.tgz",
+      "integrity": "sha512-nMWOVbkLFyEgmXZih3wyvxA9XpgyyqyfrINMHvEFqhi7uqfRl7c9ERJt6yX7vgMPrB9Uo+OJO+Spa0cFzPD01w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-core": "4.64.0",
+        "@jsonjoy.com/fs-node-builtins": "4.64.0",
+        "@jsonjoy.com/fs-node-utils": "4.64.0",
+        "thingies": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-node": {
+      "version": "4.64.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.64.0.tgz",
+      "integrity": "sha512-dO+NNkODbUli4uV42bcNrrLvq5rE7SNpdZ5TNd0dtbLsAaNK3MDiIC9lUi+brboGoIjW6vd2fB1qao60nrk5xA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-core": "4.64.0",
+        "@jsonjoy.com/fs-node-builtins": "4.64.0",
+        "@jsonjoy.com/fs-node-utils": "4.64.0",
+        "@jsonjoy.com/fs-print": "4.64.0",
+        "@jsonjoy.com/fs-snapshot": "4.64.0",
+        "glob-to-regex.js": "^1.0.0",
+        "thingies": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-node-builtins": {
+      "version": "4.64.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.64.0.tgz",
+      "integrity": "sha512-/o7WRFhUWaM/fOrslwLZGnzn4RmRILykn+lAL+mNObqqRNw+CQSiij6hpCeZ+C7buhdoVo7go/OYqzaSUfDYmA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-node-to-fsa": {
+      "version": "4.64.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.64.0.tgz",
+      "integrity": "sha512-WDD9WVs0hb7UAEKTgZW2f66WDrbj7gIIWwpP3spbLyXa0rghtUaFTB8L4gdR3ZCWwiKIsj38/CNijpVmpnuPUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-fsa": "4.64.0",
+        "@jsonjoy.com/fs-node-builtins": "4.64.0",
+        "@jsonjoy.com/fs-node-utils": "4.64.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-node-utils": {
+      "version": "4.64.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.64.0.tgz",
+      "integrity": "sha512-k5Indsx9hWW9xSF7Y6oSKKwtCUNhzZxadub3owhIlitc+iMRVlPPdX2duTKQWBL3qNWpXya8jykgaaWpheeS4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-node-builtins": "4.64.0",
+        "glob-to-regex.js": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-print": {
+      "version": "4.64.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.64.0.tgz",
+      "integrity": "sha512-PHZFccchvkhWrwPWHjmVAhbC3vSHCtyZvlZfJJ3ho2bnzl450hXri6/8e6pbkWdH+SkmLXNml0sV8e5HDAfxKw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-node-utils": "4.64.0",
+        "tree-dump": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot": {
+      "version": "4.64.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.64.0.tgz",
+      "integrity": "sha512-oM7UDeL83q6NBzzsfKAsYKXKVXlykKFqqOLh4xZZKAzzROTlInkPbc6LTDGThEOnPiFiUzA7tYziHG9xavd76Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/buffers": "^17.65.0",
+        "@jsonjoy.com/fs-node-utils": "4.64.0",
+        "@jsonjoy.com/json-pack": "^17.65.0",
+        "@jsonjoy.com/util": "^17.65.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/base64": {
+      "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-17.67.0.tgz",
+      "integrity": "sha512-5SEsJGsm15aP8TQGkDfJvz9axgPwAEm98S5DxOuYe8e1EbfajcDmgeXXzccEjh+mLnjqEKrkBdjHWS5vFNwDdw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/codegen": {
+      "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-17.67.0.tgz",
+      "integrity": "sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pack": {
+      "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-17.67.0.tgz",
+      "integrity": "sha512-t0ejURcGaZsn1ClbJ/3kFqSOjlryd92eQY465IYrezsXmPcfHPE/av4twRSxf6WE+TkZgLY+71vCZbiIiFKA/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/base64": "17.67.0",
+        "@jsonjoy.com/buffers": "17.67.0",
+        "@jsonjoy.com/codegen": "17.67.0",
+        "@jsonjoy.com/json-pointer": "17.67.0",
+        "@jsonjoy.com/util": "17.67.0",
+        "hyperdyperid": "^1.2.0",
+        "thingies": "^2.5.0",
+        "tree-dump": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pointer": {
+      "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-17.67.0.tgz",
+      "integrity": "sha512-+iqOFInH+QZGmSuaybBUNdh7yvNrXvqR+h3wjXm0N/3JK1EyyFAeGJvqnmQL61d1ARLlk/wJdFKSL+LHJ1eaUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/util": "17.67.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/util": {
+      "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-17.67.0.tgz",
+      "integrity": "sha512-6+8xBaz1rLSohlGh68D1pdw3AwDi9xydm8QNlAFkvnavCJYSze+pxoW2VKP8p308jtlMRLs5NTHfPlZLd4w7ew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/buffers": "17.67.0",
+        "@jsonjoy.com/codegen": "17.67.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/json-pack": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.21.0.tgz",
+      "integrity": "sha512-+AKG+R2cfZMShzrF2uQw34v3zbeDYUqnQ+jg7ORic3BGtfw9p/+N6RJbq/kkV8JmYZaINknaEQ2m0/f693ZPpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/base64": "^1.1.2",
+        "@jsonjoy.com/buffers": "^1.2.0",
+        "@jsonjoy.com/codegen": "^1.0.0",
+        "@jsonjoy.com/json-pointer": "^1.0.2",
+        "@jsonjoy.com/util": "^1.9.0",
+        "hyperdyperid": "^1.2.0",
+        "thingies": "^2.5.0",
+        "tree-dump": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/json-pack/node_modules/@jsonjoy.com/buffers": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
+      "integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/json-pointer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-1.0.2.tgz",
+      "integrity": "sha512-Fsn6wM2zlDzY1U+v4Nc8bo3bVqgfNTGcn6dMgs6FjrEnt4ZCe60o6ByKRjOGlI2gow0aE/Q41QOigdTqkyK5fg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/codegen": "^1.0.0",
+        "@jsonjoy.com/util": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/util": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.9.0.tgz",
+      "integrity": "sha512-pLuQo+VPRnN8hfPqUTLTHk126wuYdXVxE6aDmjSeV4NCAgyxWbiOIeNJVtID3h1Vzpoi9m4jXezf73I6LgabgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/buffers": "^1.0.0",
+        "@jsonjoy.com/codegen": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/util/node_modules/@jsonjoy.com/buffers": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
+      "integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.5",
       "license": "MIT"
@@ -3490,6 +4955,18 @@
         "react": ">=16"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "license": "MIT",
@@ -3517,6 +4994,163 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@peculiar/asn1-cms": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.8.0.tgz",
+      "integrity": "sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "@peculiar/asn1-x509-attr": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-csr": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.8.0.tgz",
+      "integrity": "sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.8.0.tgz",
+      "integrity": "sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pfx": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.8.0.tgz",
+      "integrity": "sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.8.0",
+        "@peculiar/asn1-pkcs8": "^2.8.0",
+        "@peculiar/asn1-rsa": "^2.8.0",
+        "@peculiar/asn1-schema": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs8": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.8.0.tgz",
+      "integrity": "sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs9": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.8.0.tgz",
+      "integrity": "sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.8.0",
+        "@peculiar/asn1-pfx": "^2.8.0",
+        "@peculiar/asn1-pkcs8": "^2.8.0",
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "@peculiar/asn1-x509-attr": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.8.0.tgz",
+      "integrity": "sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
+      "integrity": "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.8.0.tgz",
+      "integrity": "sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509-attr": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.8.0.tgz",
+      "integrity": "sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+      "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/x509": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
+      "integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.0",
+        "@peculiar/asn1-csr": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.0",
+        "@peculiar/asn1-pkcs9": "^2.6.0",
+        "@peculiar/asn1-rsa": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "pvtsutils": "^1.3.6",
+        "reflect-metadata": "^0.2.2",
+        "tslib": "^2.8.1",
+        "tsyringe": "^4.10.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -3969,13 +5603,15 @@
       }
     },
     "node_modules/@types/express": {
-      "version": "4.17.21",
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
         "@types/qs": "*",
-        "@types/serve-static": "*"
+        "@types/serve-static": "^1"
       }
     },
     "node_modules/@types/express-serve-static-core": {
@@ -4555,6 +6191,15 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/ansis": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-3.17.0.tgz",
+      "integrity": "sha512-0qWUglt9JEqLFr3w1I1pbrChn1grhaiAR2ocX1PP/flRmxgtwTzPFFFnfIlD6aMOLQZgSuCRlidD70lvx8yhzg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "license": "ISC",
@@ -4594,6 +6239,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/asn1js": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.5",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/astring": {
       "version": "1.9.0",
       "license": "MIT",
@@ -4618,7 +6277,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.21",
+      "version": "10.5.2",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.2.tgz",
+      "integrity": "sha512-rD5t5DwOjJdmSORcTq64j8MawTC+tbQ+HHqjR4NDumamy/ambn1UJrlKL+KdwujWxMkFjPM3pPHOEA9tl4767Q==",
       "funding": [
         {
           "type": "opencollective",
@@ -4635,10 +6296,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.24.4",
-        "caniuse-lite": "^1.0.30001702",
-        "fraction.js": "^4.3.7",
-        "normalize-range": "^0.1.2",
+        "browserslist": "^4.28.4",
+        "caniuse-lite": "^1.0.30001799",
+        "fraction.js": "^5.3.4",
         "picocolors": "^1.1.1",
         "postcss-value-parser": "^4.2.0"
       },
@@ -4726,6 +6386,18 @@
       "version": "1.0.2",
       "license": "MIT"
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.43",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
+      "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/batch": {
       "version": "0.6.1",
       "license": "MIT"
@@ -4758,21 +6430,23 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.3",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
+        "bytes": "~3.1.2",
         "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.13.0",
-        "raw-body": "2.5.2",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
+        "unpipe": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.8",
@@ -4781,14 +6455,47 @@
     },
     "node_modules/body-parser/node_modules/debug": {
       "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
     },
+    "node_modules/body-parser/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/body-parser/node_modules/ms": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/body-parser/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/bonjour-service": {
       "version": "1.3.0",
@@ -4841,7 +6548,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.24.4",
+      "version": "4.28.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
+      "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
       "funding": [
         {
           "type": "opencollective",
@@ -4858,10 +6567,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001688",
-        "electron-to-chromium": "^1.5.73",
-        "node-releases": "^2.0.19",
-        "update-browserslist-db": "^1.1.1"
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001803",
+        "electron-to-chromium": "^1.5.389",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -4874,11 +6584,35 @@
       "version": "1.1.2",
       "license": "MIT"
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/bytestreamjs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
+      "integrity": "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/cacheable-lookup": {
@@ -4981,7 +6715,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001715",
+      "version": "1.0.30001805",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001805.tgz",
+      "integrity": "sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA==",
       "funding": [
         {
           "type": "opencollective",
@@ -5323,14 +7059,16 @@
       }
     },
     "node_modules/compression": {
-      "version": "1.8.0",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
       "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
         "compressible": "~2.0.18",
         "debug": "2.6.9",
         "negotiator": "~0.6.4",
-        "on-headers": "~1.0.2",
+        "on-headers": "~1.1.0",
         "safe-buffer": "5.2.1",
         "vary": "~1.1.2"
       },
@@ -5414,6 +7152,8 @@
     },
     "node_modules/content-type": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -5629,7 +7369,9 @@
       }
     },
     "node_modules/css-has-pseudo": {
-      "version": "7.0.2",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/css-has-pseudo/-/css-has-pseudo-7.0.3.tgz",
+      "integrity": "sha512-oG+vKuGyqe/xvEMoxAQrhi7uY16deJR3i7wwhBerVrGQKSqUC5GiOVxTpM9F9B9hw0J+eKeOWLH7E9gZ1Dr5rA==",
       "funding": [
         {
           "type": "github",
@@ -5803,7 +7545,9 @@
       }
     },
     "node_modules/cssdb": {
-      "version": "8.2.5",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-8.9.0.tgz",
+      "integrity": "sha512-J8jOU/hLjaXcO1LldOLraJSQpfLXRKof0I7mtbRyOy2AAXgqst0x9rlgi2qXeD6d0ou3ZLqcPAMqYVbpCbrxEw==",
       "funding": [
         {
           "type": "opencollective",
@@ -6011,6 +7755,34 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/default-gateway": {
@@ -6441,7 +8213,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.144",
+      "version": "1.5.389",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
+      "integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -6789,37 +8563,39 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.2",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.3",
-        "content-disposition": "0.5.4",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.7.1",
-        "cookie-signature": "1.0.6",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
         "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.3.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
         "merge-descriptors": "1.0.3",
         "methods": "~1.1.2",
-        "on-finished": "2.4.1",
+        "on-finished": "~2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.12",
+        "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "6.13.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
-        "send": "0.19.0",
-        "serve-static": "1.16.2",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
         "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
+        "statuses": "~2.0.1",
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
@@ -7254,13 +9030,15 @@
       }
     },
     "node_modules/fraction.js": {
-      "version": "4.3.7",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
       "license": "MIT",
       "engines": {
         "node": "*"
       },
       "funding": {
-        "type": "patreon",
+        "type": "github",
         "url": "https://github.com/sponsors/rawify"
       }
     },
@@ -7428,6 +9206,22 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/glob-to-regex.js": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/glob-to-regex.js/-/glob-to-regex.js-1.2.0.tgz",
+      "integrity": "sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
       }
     },
     "node_modules/glob-to-regexp": {
@@ -8290,8 +10084,19 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/hyperdyperid": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
+      "integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.18"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
@@ -8567,6 +10372,39 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container/node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-installed-globally": {
       "version": "0.4.0",
       "license": "MIT",
@@ -8576,6 +10414,18 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-network-error": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.2.tgz",
+      "integrity": "sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8839,11 +10689,13 @@
       }
     },
     "node_modules/launch-editor": {
-      "version": "2.10.0",
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.14.1.tgz",
+      "integrity": "sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==",
       "license": "MIT",
       "dependencies": {
-        "picocolors": "^1.0.0",
-        "shell-quote": "^1.8.1"
+        "picocolors": "^1.1.1",
+        "shell-quote": "^1.8.4"
       }
     },
     "node_modules/leven": {
@@ -9331,6 +11183,8 @@
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -10178,7 +12032,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -10228,8 +12084,13 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.19",
-      "license": "MIT"
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/nopt": {
       "version": "1.0.10",
@@ -10248,13 +12109,6 @@
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/normalize-range": {
-      "version": "0.1.2",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10367,6 +12221,8 @@
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10415,7 +12271,9 @@
       }
     },
     "node_modules/on-headers": {
-      "version": "1.0.2",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -10470,6 +12328,15 @@
         "node": ">=12.20"
       }
     },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/p-limit": {
       "version": "4.0.0",
       "license": "MIT",
@@ -10509,6 +12376,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-retry": {
       "version": "4.6.2",
       "license": "MIT",
@@ -10520,11 +12403,16 @@
         "node": ">=8"
       }
     },
-    "node_modules/p-retry/node_modules/retry": {
-      "version": "0.13.1",
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
       "license": "MIT",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
       "engines": {
-        "node": ">= 4"
+        "node": ">=8"
       }
     },
     "node_modules/p-try": {
@@ -10786,8 +12674,27 @@
         "node": ">=4"
       }
     },
+    "node_modules/pkijs": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.4.0.tgz",
+      "integrity": "sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@noble/hashes": "1.4.0",
+        "asn1js": "^3.0.6",
+        "bytestreamjs": "^2.0.1",
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/postcss": {
-      "version": "8.5.3",
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -10804,7 +12711,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.8",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -10874,7 +12781,9 @@
       }
     },
     "node_modules/postcss-color-functional-notation": {
-      "version": "7.0.9",
+      "version": "7.0.12",
+      "resolved": "https://registry.npmjs.org/postcss-color-functional-notation/-/postcss-color-functional-notation-7.0.12.tgz",
+      "integrity": "sha512-TLCW9fN5kvO/u38/uesdpbx3e8AkTYhMvDZYa9JpmImWuTE99bDQ7GU7hdOADIZsiI9/zuxfAJxny/khknp1Zw==",
       "funding": [
         {
           "type": "github",
@@ -10887,10 +12796,10 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/css-color-parser": "^3.0.9",
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3",
-        "@csstools/postcss-progressive-custom-properties": "^4.0.1",
+        "@csstools/css-color-parser": "^3.1.0",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.1",
         "@csstools/utilities": "^2.0.0"
       },
       "engines": {
@@ -10979,7 +12888,9 @@
       }
     },
     "node_modules/postcss-custom-media": {
-      "version": "11.0.5",
+      "version": "11.0.6",
+      "resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-11.0.6.tgz",
+      "integrity": "sha512-C4lD4b7mUIw+RZhtY7qUbf4eADmb7Ey8BFA2px9jUbwg7pjTZDl4KY4bvlUV+/vXQvzQRfiGEVJyAbtOsCMInw==",
       "funding": [
         {
           "type": "github",
@@ -10992,10 +12903,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@csstools/cascade-layer-name-parser": "^2.0.4",
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3",
-        "@csstools/media-query-list-parser": "^4.0.2"
+        "@csstools/cascade-layer-name-parser": "^2.0.5",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "@csstools/media-query-list-parser": "^4.0.3"
       },
       "engines": {
         "node": ">=18"
@@ -11005,7 +12916,9 @@
       }
     },
     "node_modules/postcss-custom-properties": {
-      "version": "14.0.4",
+      "version": "14.0.6",
+      "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-14.0.6.tgz",
+      "integrity": "sha512-fTYSp3xuk4BUeVhxCSJdIPhDLpJfNakZKoiTDx7yRGCdlZrSJR7mWKVOBS4sBF+5poPQFMj2YdXx1VHItBGihQ==",
       "funding": [
         {
           "type": "github",
@@ -11018,9 +12931,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@csstools/cascade-layer-name-parser": "^2.0.4",
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3",
+        "@csstools/cascade-layer-name-parser": "^2.0.5",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
         "@csstools/utilities": "^2.0.0",
         "postcss-value-parser": "^4.2.0"
       },
@@ -11032,7 +12945,9 @@
       }
     },
     "node_modules/postcss-custom-selectors": {
-      "version": "8.0.4",
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-custom-selectors/-/postcss-custom-selectors-8.0.5.tgz",
+      "integrity": "sha512-9PGmckHQswiB2usSO6XMSswO2yFWVoCAuih1yl9FVcwkscLjRKjwsjM3t+NIWpSU2Jx3eOiK2+t4vVTQaoCHHg==",
       "funding": [
         {
           "type": "github",
@@ -11045,9 +12960,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@csstools/cascade-layer-name-parser": "^2.0.4",
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3",
+        "@csstools/cascade-layer-name-parser": "^2.0.5",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
         "postcss-selector-parser": "^7.0.0"
       },
       "engines": {
@@ -11145,7 +13060,9 @@
       }
     },
     "node_modules/postcss-double-position-gradients": {
-      "version": "6.0.1",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-double-position-gradients/-/postcss-double-position-gradients-6.0.4.tgz",
+      "integrity": "sha512-m6IKmxo7FxSP5nF2l63QbCC3r+bWpFUWmZXZf096WxG0m7Vl1Q1+ruFOhpdDRmKrRS+S3Jtk+TVk/7z0+BVK6g==",
       "funding": [
         {
           "type": "github",
@@ -11158,7 +13075,7 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/postcss-progressive-custom-properties": "^4.0.1",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.1",
         "@csstools/utilities": "^2.0.0",
         "postcss-value-parser": "^4.2.0"
       },
@@ -11267,7 +13184,9 @@
       }
     },
     "node_modules/postcss-lab-function": {
-      "version": "7.0.9",
+      "version": "7.0.12",
+      "resolved": "https://registry.npmjs.org/postcss-lab-function/-/postcss-lab-function-7.0.12.tgz",
+      "integrity": "sha512-tUcyRk1ZTPec3OuKFsqtRzW2Go5lehW29XA21lZ65XmzQkz43VY2tyWEC202F7W3mILOjw0voOiuxRGTsN+J9w==",
       "funding": [
         {
           "type": "github",
@@ -11280,10 +13199,10 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/css-color-parser": "^3.0.9",
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3",
-        "@csstools/postcss-progressive-custom-properties": "^4.0.1",
+        "@csstools/css-color-parser": "^3.1.0",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.1",
         "@csstools/utilities": "^2.0.0"
       },
       "engines": {
@@ -11510,7 +13429,9 @@
       }
     },
     "node_modules/postcss-nesting": {
-      "version": "13.0.1",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-13.0.2.tgz",
+      "integrity": "sha512-1YCI290TX+VP0U/K/aFxzHzQWHWURL+CtHMSbex1lCdpXD1SoR2sYuxDu5aNI9lPoXpKTCggFZiDJbwylU0LEQ==",
       "funding": [
         {
           "type": "github",
@@ -11523,7 +13444,7 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/selector-resolve-nested": "^3.0.0",
+        "@csstools/selector-resolve-nested": "^3.1.0",
         "@csstools/selector-specificity": "^5.0.0",
         "postcss-selector-parser": "^7.0.0"
       },
@@ -11737,7 +13658,9 @@
       }
     },
     "node_modules/postcss-preset-env": {
-      "version": "10.1.6",
+      "version": "10.6.1",
+      "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-10.6.1.tgz",
+      "integrity": "sha512-yrk74d9EvY+W7+lO9Aj1QmjWY9q5NsKjK2V9drkOPZB/X6KZ0B3igKsHUYakb7oYVhnioWypQX3xGuePf89f3g==",
       "funding": [
         {
           "type": "github",
@@ -11750,62 +13673,70 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/postcss-cascade-layers": "^5.0.1",
-        "@csstools/postcss-color-function": "^4.0.9",
-        "@csstools/postcss-color-mix-function": "^3.0.9",
-        "@csstools/postcss-content-alt-text": "^2.0.5",
-        "@csstools/postcss-exponential-functions": "^2.0.8",
+        "@csstools/postcss-alpha-function": "^1.0.1",
+        "@csstools/postcss-cascade-layers": "^5.0.2",
+        "@csstools/postcss-color-function": "^4.0.12",
+        "@csstools/postcss-color-function-display-p3-linear": "^1.0.1",
+        "@csstools/postcss-color-mix-function": "^3.0.12",
+        "@csstools/postcss-color-mix-variadic-function-arguments": "^1.0.2",
+        "@csstools/postcss-content-alt-text": "^2.0.8",
+        "@csstools/postcss-contrast-color-function": "^2.0.12",
+        "@csstools/postcss-exponential-functions": "^2.0.9",
         "@csstools/postcss-font-format-keywords": "^4.0.0",
-        "@csstools/postcss-gamut-mapping": "^2.0.9",
-        "@csstools/postcss-gradients-interpolation-method": "^5.0.9",
-        "@csstools/postcss-hwb-function": "^4.0.9",
-        "@csstools/postcss-ic-unit": "^4.0.1",
+        "@csstools/postcss-gamut-mapping": "^2.0.11",
+        "@csstools/postcss-gradients-interpolation-method": "^5.0.12",
+        "@csstools/postcss-hwb-function": "^4.0.12",
+        "@csstools/postcss-ic-unit": "^4.0.4",
         "@csstools/postcss-initial": "^2.0.1",
-        "@csstools/postcss-is-pseudo-class": "^5.0.1",
-        "@csstools/postcss-light-dark-function": "^2.0.8",
+        "@csstools/postcss-is-pseudo-class": "^5.0.3",
+        "@csstools/postcss-light-dark-function": "^2.0.11",
         "@csstools/postcss-logical-float-and-clear": "^3.0.0",
         "@csstools/postcss-logical-overflow": "^2.0.0",
         "@csstools/postcss-logical-overscroll-behavior": "^2.0.0",
         "@csstools/postcss-logical-resize": "^3.0.0",
-        "@csstools/postcss-logical-viewport-units": "^3.0.3",
-        "@csstools/postcss-media-minmax": "^2.0.8",
-        "@csstools/postcss-media-queries-aspect-ratio-number-values": "^3.0.4",
+        "@csstools/postcss-logical-viewport-units": "^3.0.4",
+        "@csstools/postcss-media-minmax": "^2.0.9",
+        "@csstools/postcss-media-queries-aspect-ratio-number-values": "^3.0.5",
         "@csstools/postcss-nested-calc": "^4.0.0",
-        "@csstools/postcss-normalize-display-values": "^4.0.0",
-        "@csstools/postcss-oklab-function": "^4.0.9",
-        "@csstools/postcss-progressive-custom-properties": "^4.0.1",
-        "@csstools/postcss-random-function": "^2.0.0",
-        "@csstools/postcss-relative-color-syntax": "^3.0.9",
+        "@csstools/postcss-normalize-display-values": "^4.0.1",
+        "@csstools/postcss-oklab-function": "^4.0.12",
+        "@csstools/postcss-position-area-property": "^1.0.0",
+        "@csstools/postcss-progressive-custom-properties": "^4.2.1",
+        "@csstools/postcss-property-rule-prelude-list": "^1.0.0",
+        "@csstools/postcss-random-function": "^2.0.1",
+        "@csstools/postcss-relative-color-syntax": "^3.0.12",
         "@csstools/postcss-scope-pseudo-class": "^4.0.1",
-        "@csstools/postcss-sign-functions": "^1.1.3",
-        "@csstools/postcss-stepped-value-functions": "^4.0.8",
-        "@csstools/postcss-text-decoration-shorthand": "^4.0.2",
-        "@csstools/postcss-trigonometric-functions": "^4.0.8",
+        "@csstools/postcss-sign-functions": "^1.1.4",
+        "@csstools/postcss-stepped-value-functions": "^4.0.9",
+        "@csstools/postcss-syntax-descriptor-syntax-production": "^1.0.1",
+        "@csstools/postcss-system-ui-font-family": "^1.0.0",
+        "@csstools/postcss-text-decoration-shorthand": "^4.0.3",
+        "@csstools/postcss-trigonometric-functions": "^4.0.9",
         "@csstools/postcss-unset-value": "^4.0.0",
-        "autoprefixer": "^10.4.21",
-        "browserslist": "^4.24.4",
+        "autoprefixer": "^10.4.23",
+        "browserslist": "^4.28.1",
         "css-blank-pseudo": "^7.0.1",
-        "css-has-pseudo": "^7.0.2",
+        "css-has-pseudo": "^7.0.3",
         "css-prefers-color-scheme": "^10.0.0",
-        "cssdb": "^8.2.5",
+        "cssdb": "^8.6.0",
         "postcss-attribute-case-insensitive": "^7.0.1",
         "postcss-clamp": "^4.1.0",
-        "postcss-color-functional-notation": "^7.0.9",
+        "postcss-color-functional-notation": "^7.0.12",
         "postcss-color-hex-alpha": "^10.0.0",
         "postcss-color-rebeccapurple": "^10.0.0",
-        "postcss-custom-media": "^11.0.5",
-        "postcss-custom-properties": "^14.0.4",
-        "postcss-custom-selectors": "^8.0.4",
+        "postcss-custom-media": "^11.0.6",
+        "postcss-custom-properties": "^14.0.6",
+        "postcss-custom-selectors": "^8.0.5",
         "postcss-dir-pseudo-class": "^9.0.1",
-        "postcss-double-position-gradients": "^6.0.1",
+        "postcss-double-position-gradients": "^6.0.4",
         "postcss-focus-visible": "^10.0.1",
         "postcss-focus-within": "^9.0.1",
         "postcss-font-variant": "^5.0.0",
         "postcss-gap-properties": "^6.0.0",
         "postcss-image-set-function": "^7.0.0",
-        "postcss-lab-function": "^7.0.9",
+        "postcss-lab-function": "^7.0.12",
         "postcss-logical": "^8.1.0",
-        "postcss-nesting": "^13.0.1",
+        "postcss-nesting": "^13.0.2",
         "postcss-opacity-percentage": "^3.0.0",
         "postcss-overflow-shorthand": "^6.0.0",
         "postcss-page-break": "^3.0.4",
@@ -12090,11 +14021,32 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/qs": {
-      "version": "6.13.0",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.6"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -12153,14 +14105,45 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.2",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -12355,7 +14338,9 @@
       }
     },
     "node_modules/react-loadable-ssr-addon-v5-slorber": {
-      "version": "1.0.1",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/react-loadable-ssr-addon-v5-slorber/-/react-loadable-ssr-addon-v5-slorber-1.0.3.tgz",
+      "integrity": "sha512-GXfh9VLwB5ERaCsU6RULh7tkemeX15aNh6wuMEBtfdyMa7fFG8TXrhXlx1SoEK2Ty/l6XIkzzYIQmyaWW3JgdQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.3"
@@ -12522,6 +14507,12 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0"
     },
     "node_modules/regenerate": {
       "version": "1.4.2",
@@ -13070,6 +15061,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "license": "MIT",
@@ -13117,6 +15117,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "funding": [
@@ -13158,6 +15170,8 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
     "node_modules/sax": {
@@ -13167,6 +15181,12 @@
     "node_modules/scheduler": {
       "version": "0.26.0",
       "license": "MIT"
+    },
+    "node_modules/schema-dts": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/schema-dts/-/schema-dts-1.1.5.tgz",
+      "integrity": "sha512-RJr9EaCmsLzBX2NDiO5Z3ux2BVosNZN5jo0gWgsyKvxKIUL5R3swNvoorulAeL9kLB0iTSX7V6aokhla2m7xbg==",
+      "license": "Apache-2.0"
     },
     "node_modules/schema-utils": {
       "version": "4.3.2",
@@ -13464,7 +15484,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.2",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -13489,12 +15511,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -13506,11 +15530,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -13521,6 +15547,8 @@
     },
     "node_modules/side-channel-map": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -13537,6 +15565,8 @@
     },
     "node_modules/side-channel-weakmap": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -14008,6 +16038,22 @@
       "version": "0.2.0",
       "license": "MIT"
     },
+    "node_modules/thingies": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/thingies/-/thingies-2.6.0.tgz",
+      "integrity": "sha512-rMHRjmlFLM1R96UYPvpmnc3LYtdFrT33JIB7L9hetGue1qAPfn1N2LJeEjxUSidu1Iku+haLZXDuEXUHNGO/lg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "^2"
+      }
+    },
     "node_modules/thunky": {
       "version": "1.1.0",
       "license": "MIT"
@@ -14019,6 +16065,15 @@
     "node_modules/tiny-warning": {
       "version": "1.0.3",
       "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -14107,6 +16162,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/tree-dump": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.1.0.tgz",
+      "integrity": "sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "license": "MIT",
@@ -14127,6 +16198,24 @@
       "version": "2.8.1",
       "license": "0BSD"
     },
+    "node_modules/tsyringe": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+      "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/tsyringe/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
     "node_modules/type-fest": {
       "version": "2.19.0",
       "license": "(MIT OR CC0-1.0)",
@@ -14139,6 +16228,8 @@
     },
     "node_modules/type-is": {
       "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
       "license": "MIT",
       "dependencies": {
         "media-typer": "0.3.0",
@@ -14346,7 +16437,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.3",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "funding": [
         {
           "type": "opencollective",
@@ -15011,6 +17104,36 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wsl-utils/node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/xdg-basedir": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "3.7.0",
+    "@docusaurus/plugin-content-docs": "^3.10.2",
     "@docusaurus/preset-classic": "3.7.0",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",

--- a/plugins/generate-glossary/index.js
+++ b/plugins/generate-glossary/index.js
@@ -36,21 +36,26 @@ async function fetchDefinitions(terms) {
   const uris = terms
     .map((t) => `<${t.codata_uri}>`)
     .join(" ");
-  const query = `PREFIX skos: <http://www.w3.org/2004/02/skos/core#> SELECT ?uri ?def WHERE { VALUES ?uri { ${uris} } ?uri skos:definition ?def }`;
+  const query = `PREFIX skos: <http://www.w3.org/2004/02/skos/core#> SELECT ?uri ?label ?def WHERE { VALUES ?uri { ${uris} } OPTIONAL { ?uri skos:prefLabel ?label } OPTIONAL { ?uri skos:definition ?def } }`;
 
   try {
     const result = await fetchSparql(query);
     const definitions = {};
+    const labels = {};
     if (result?.results?.bindings) {
       for (const binding of result.results.bindings) {
         const uri = binding.uri?.value;
         const def = binding.def?.value;
+        const label = binding.label?.value;
         if (uri && def) {
           definitions[uri] = def;
         }
+        if (uri && label && !labels[uri]) {
+          labels[uri] = label;
+        }
       }
     }
-    return definitions;
+    return { definitions, labels };
   } catch (error) {
     console.warn(
       `[generate-glossary] Failed to fetch definitions from SPARQL endpoint: ${error.message}`,
@@ -94,10 +99,11 @@ module.exports = function pluginGenerateGlossary(context, options) {
       console.info(
         `[generate-glossary] Fetching definitions from CODATA SPARQL endpoint...`,
       );
-      const definitions = await fetchDefinitions(glossaryTerms);
+      const { definitions, labels } = await fetchDefinitions(glossaryTerms);
 
       for (const term of glossaryTerms) {
         term.codataDefinition = definitions[term.codata_uri] || null;
+        term.codataLabel = labels[term.codata_uri] || null;
       }
 
       return actions.createData(

--- a/plugins/generate-glossary/index.js
+++ b/plugins/generate-glossary/index.js
@@ -1,0 +1,109 @@
+const https = require("https");
+
+const SPARQL_ENDPOINT =
+  "https://vocabs.ardc.edu.au/repository/api/sparql/codata_codata-research-data-management-terminology_current";
+
+function fetchSparql(query) {
+  return new Promise((resolve, reject) => {
+    const url = new URL(SPARQL_ENDPOINT);
+    url.searchParams.set("query", query);
+    url.searchParams.set("output", "json");
+
+    const req = https.get(url.toString(), { headers: { Accept: "application/sparql-results+json" } }, (res) => {
+      let data = "";
+      res.on("data", (chunk) => (data += chunk));
+      res.on("end", () => {
+        try {
+          resolve(JSON.parse(data));
+        } catch (e) {
+          reject(new Error(`Invalid JSON from SPARQL endpoint`));
+        }
+      });
+    });
+    req.on("error", reject);
+    req.setTimeout(15000, () => {
+      req.destroy();
+      reject(new Error("SPARQL request timed out"));
+    });
+  });
+}
+
+async function fetchDefinitions(terms) {
+  if (terms.length === 0) {
+    return {};
+  }
+
+  const uris = terms
+    .map((t) => `<${t.codata_uri}>`)
+    .join(" ");
+  const query = `PREFIX skos: <http://www.w3.org/2004/02/skos/core#> SELECT ?uri ?def WHERE { VALUES ?uri { ${uris} } ?uri skos:definition ?def }`;
+
+  try {
+    const result = await fetchSparql(query);
+    const definitions = {};
+    if (result?.results?.bindings) {
+      for (const binding of result.results.bindings) {
+        const uri = binding.uri?.value;
+        const def = binding.def?.value;
+        if (uri && def) {
+          definitions[uri] = def;
+        }
+      }
+    }
+    return definitions;
+  } catch (error) {
+    console.warn(
+      `[generate-glossary] Failed to fetch definitions from SPARQL endpoint: ${error.message}`,
+    );
+    return {};
+  }
+}
+
+module.exports = function pluginGenerateGlossary(context, options) {
+  return {
+    name: "generate-glossary",
+
+    async allContentLoaded({ allContent, actions }) {
+      const docsContent =
+        allContent["docusaurus-plugin-content-docs"]?.default;
+
+      if (!docsContent || !docsContent.loadedVersions) {
+        return;
+      }
+
+      const glossaryTerms = [];
+
+      for (const version of docsContent.loadedVersions) {
+        if (!version.docs) continue;
+
+        for (const doc of version.docs) {
+          const { frontMatter } = doc;
+          if (frontMatter?.for_glossary !== true) continue;
+          if (!frontMatter?.codata_uri) continue;
+
+          glossaryTerms.push({
+            term: frontMatter.glossary_term || doc.title || "",
+            codata_uri: frontMatter.codata_uri,
+            permalink: doc.permalink,
+          });
+        }
+      }
+
+      glossaryTerms.sort((a, b) => a.term.localeCompare(b.term));
+
+      console.info(
+        `[generate-glossary] Fetching definitions from CODATA SPARQL endpoint...`,
+      );
+      const definitions = await fetchDefinitions(glossaryTerms);
+
+      for (const term of glossaryTerms) {
+        term.codataDefinition = definitions[term.codata_uri] || null;
+      }
+
+      return actions.createData(
+        "glossary-manifest.json",
+        JSON.stringify(glossaryTerms),
+      );
+    },
+  };
+};

--- a/src/components/GlossaryBadge/index.tsx
+++ b/src/components/GlossaryBadge/index.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+
+function slugify(codataUri: string): string {
+  const path = codataUri.replace(
+    /^https:\/\/terms\.codata\.org\/rdmt\//,
+    "",
+  );
+  return "term-" + path.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
+}
+
+export type GlossaryBadgeInfo = {
+  href: string;
+  anchorId: string;
+};
+
+export const GlossaryBadgeContext = React.createContext<GlossaryBadgeInfo | null>(null);
+
+export function useGlossaryBadge(): GlossaryBadgeInfo | null {
+  return React.useContext(GlossaryBadgeContext);
+}
+
+export function createGlossaryBadgeInfo(
+  codataUri: string,
+): GlossaryBadgeInfo | null {
+  if (!codataUri || typeof codataUri !== "string") return null;
+
+  const anchor = slugify(codataUri);
+
+  return {
+    href: "/docs/glossary/#" + anchor,
+    anchorId: anchor,
+  };
+}

--- a/src/components/RenderGlossary/index.tsx
+++ b/src/components/RenderGlossary/index.tsx
@@ -25,26 +25,6 @@ export default function RenderGlossary() {
 
   return (
     <div className="glossary">
-      <p className="glossary__intro">
-        This glossary is aligned with the{" "}
-        <a
-          href="https://terms.codata.org/rdmt"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          CODATA Research Data Management Terminology (RDM-T)
-        </a>
-        , a SKOS-controlled vocabulary maintained by the{" "}
-        <a
-          href="https://codata.org/initiatives/data-science-and-stewardship/rdm-terminology-wg"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          CODATA RDM Terminology Working Group
-        </a>
-        .
-      </p>
-
       <ul className="glossary__list">
         {glossaryData.map((term, index) => {
           const anchorId = slugify(term.codata_uri);
@@ -96,6 +76,26 @@ export default function RenderGlossary() {
           );
         })}
       </ul>
+
+      <p className="glossary__intro">
+        This glossary is aligned with the{" "}
+        <a
+          href="https://terms.codata.org/rdmt"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          CODATA Research Data Management Terminology (RDM-T)
+        </a>
+        , a SKOS-controlled vocabulary maintained by the{" "}
+        <a
+          href="https://codata.org/initiatives/data-science-and-stewardship/rdm-terminology-wg"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          CODATA RDM Terminology Working Group
+        </a>
+        .
+      </p>
     </div>
   );
 }

--- a/src/components/RenderGlossary/index.tsx
+++ b/src/components/RenderGlossary/index.tsx
@@ -4,7 +4,13 @@ import glossaryData from "@generated/generate-glossary/default/glossary-manifest
 
 function slugify(codataUri: string): string {
   const path = codataUri.replace(/^https:\/\/terms\.codata\.org\/rdmt\//, "");
-  return "term-" + path.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
+  return (
+    "term-" +
+    path
+      .toLowerCase()
+      .replace(/\s+/g, "-")
+      .replace(/[^a-z0-9-]/g, "")
+  );
 }
 
 export default function RenderGlossary() {
@@ -47,12 +53,14 @@ export default function RenderGlossary() {
               <div className="glossary__item-header">
                 <a href={term.permalink} className="glossary__item-link">
                   <strong>{term.term}</strong>
-                  {term.codataLabel && term.codataLabel.toLowerCase() !== term.term.toLowerCase() && (
+                </a>
+                {term.codataLabel &&
+                  term.codataLabel.toLowerCase() !==
+                    term.term.toLowerCase() && (
                     <span className="glossary__codata-label">
                       ({term.codataLabel})
                     </span>
                   )}
-                </a>
                 <a
                   href={`https://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v002/resource?uri=${encodeURIComponent(term.codata_uri)}`}
                   target="_blank"

--- a/src/components/RenderGlossary/index.tsx
+++ b/src/components/RenderGlossary/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { MoveUpRight } from "lucide-react";
 import glossaryData from "@generated/generate-glossary/default/glossary-manifest.json";
 
 function slugify(codataUri: string): string {
@@ -54,7 +55,7 @@ export default function RenderGlossary() {
                   className="glossary__codata-badge"
                   title="View in CODATA RDM-T vocabulary"
                 >
-                  CODATA ↗
+                  CODATA <MoveUpRight size={12} />
                 </a>
               </div>
               {term.codataDefinition ? (

--- a/src/components/RenderGlossary/index.tsx
+++ b/src/components/RenderGlossary/index.tsx
@@ -47,6 +47,11 @@ export default function RenderGlossary() {
               <div className="glossary__item-header">
                 <a href={term.permalink} className="glossary__item-link">
                   <strong>{term.term}</strong>
+                  {term.codataLabel && term.codataLabel.toLowerCase() !== term.term.toLowerCase() && (
+                    <span className="glossary__codata-label">
+                      ({term.codataLabel})
+                    </span>
+                  )}
                 </a>
                 <a
                   href={`https://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v002/resource?uri=${encodeURIComponent(term.codata_uri)}`}

--- a/src/components/RenderGlossary/index.tsx
+++ b/src/components/RenderGlossary/index.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import glossaryData from "@generated/generate-glossary/default/glossary-manifest.json";
+
+export default function RenderGlossary() {
+  if (glossaryData.length === 0) {
+    return (
+      <p>
+        No glossary terms found. Add <code>for_glossary: true</code> and a{" "}
+        <code>codata_uri</code> to your page front matter.
+      </p>
+    );
+  }
+
+  return (
+    <div className="glossary">
+      <p className="glossary__intro">
+        This glossary is aligned with the{" "}
+        <a
+          href="https://terms.codata.org/rdmt"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          CODATA Research Data Management Terminology (RDM-T)
+        </a>
+        , a SKOS-controlled vocabulary maintained by the{" "}
+        <a
+          href="https://codata.org/initiatives/data-science-and-stewardship/rdm-terminology-wg"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          CODATA RDM Terminology Working Group
+        </a>
+        .
+      </p>
+
+      <ul className="glossary__list">
+        {glossaryData.map((term, index) => (
+          <li key={index} className="glossary__item">
+            <div className="glossary__item-header">
+              <a href={term.permalink} className="glossary__item-link">
+                <strong>{term.term}</strong>
+              </a>
+              <a
+                href={`https://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v002/resource?uri=${encodeURIComponent(term.codata_uri)}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="glossary__codata-badge"
+                title="View in CODATA RDM-T vocabulary"
+              >
+                CODATA ↗
+              </a>
+            </div>
+            {term.codataDefinition ? (
+              <div className="glossary__definition">
+                <p className="glossary__definition-text">
+                  {term.codataDefinition}
+                </p>
+                <p className="glossary__definition-source">
+                  Source:{" "}
+                  <a
+                    href={`https://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v002/resource?uri=${encodeURIComponent(term.codata_uri)}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    CODATA RDM-T
+                  </a>
+                </p>
+              </div>
+            ) : (
+              <p className="glossary__no-definition">
+                Definition not available from CODATA
+              </p>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/RenderGlossary/index.tsx
+++ b/src/components/RenderGlossary/index.tsx
@@ -1,6 +1,11 @@
 import React from "react";
 import glossaryData from "@generated/generate-glossary/default/glossary-manifest.json";
 
+function slugify(codataUri: string): string {
+  const path = codataUri.replace(/^https:\/\/terms\.codata\.org\/rdmt\//, "");
+  return "term-" + path.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
+}
+
 export default function RenderGlossary() {
   if (glossaryData.length === 0) {
     return (
@@ -34,45 +39,48 @@ export default function RenderGlossary() {
       </p>
 
       <ul className="glossary__list">
-        {glossaryData.map((term, index) => (
-          <li key={index} className="glossary__item">
-            <div className="glossary__item-header">
-              <a href={term.permalink} className="glossary__item-link">
-                <strong>{term.term}</strong>
-              </a>
-              <a
-                href={`https://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v002/resource?uri=${encodeURIComponent(term.codata_uri)}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="glossary__codata-badge"
-                title="View in CODATA RDM-T vocabulary"
-              >
-                CODATA ↗
-              </a>
-            </div>
-            {term.codataDefinition ? (
-              <div className="glossary__definition">
-                <p className="glossary__definition-text">
-                  {term.codataDefinition}
-                </p>
-                <p className="glossary__definition-source">
-                  Source:{" "}
-                  <a
-                    href={`https://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v002/resource?uri=${encodeURIComponent(term.codata_uri)}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    CODATA RDM-T
-                  </a>
-                </p>
+        {glossaryData.map((term, index) => {
+          const anchorId = slugify(term.codata_uri);
+          return (
+            <li key={index} className="glossary__item" id={anchorId}>
+              <div className="glossary__item-header">
+                <a href={term.permalink} className="glossary__item-link">
+                  <strong>{term.term}</strong>
+                </a>
+                <a
+                  href={`https://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v002/resource?uri=${encodeURIComponent(term.codata_uri)}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="glossary__codata-badge"
+                  title="View in CODATA RDM-T vocabulary"
+                >
+                  CODATA ↗
+                </a>
               </div>
-            ) : (
-              <p className="glossary__no-definition">
-                Definition not available from CODATA
-              </p>
-            )}
-          </li>
-        ))}
+              {term.codataDefinition ? (
+                <div className="glossary__definition">
+                  <p className="glossary__definition-text">
+                    {term.codataDefinition}
+                  </p>
+                  <p className="glossary__definition-source">
+                    Source:{" "}
+                    <a
+                      href={`https://vocabs.ardc.edu.au/repository/api/lda/codata/codata-research-data-management-terminology/v002/resource?uri=${encodeURIComponent(term.codata_uri)}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      CODATA RDM-T
+                    </a>
+                  </p>
+                </div>
+              ) : (
+                <p className="glossary__no-definition">
+                  Definition not available from CODATA
+                </p>
+              )}
+            </li>
+          );
+        })}
       </ul>
     </div>
   );

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -29,3 +29,90 @@
 
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
 }
+
+/* Glossary styles */
+.glossary__intro {
+  font-style: italic;
+  color: var(--ifm-font-color-base);
+  opacity: 0.85;
+}
+
+.glossary__list {
+  list-style: none;
+  padding: 0;
+}
+
+.glossary__item {
+  padding: 1rem 0;
+  border-bottom: 1px solid var(--ifm-toc-border-color);
+}
+
+.glossary__item:last-child {
+  border-bottom: none;
+}
+
+.glossary__item-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.glossary__item-link {
+  text-decoration: none;
+  font-size: 1.125rem;
+}
+
+.glossary__item-link:hover {
+  text-decoration: underline;
+}
+
+.glossary__codata-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.6rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  border-radius: 0.375rem;
+  background-color: var(--ifm-color-primary);
+  color: #fff;
+  text-decoration: none;
+  opacity: 0.85;
+}
+
+.glossary__codata-badge:hover {
+  opacity: 1;
+  text-decoration: none;
+}
+
+.glossary__definition {
+  margin-top: 0.5rem;
+}
+
+.glossary__definition-text {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-left: 3px solid var(--ifm-color-primary-lightest);
+  background-color: var(--ifm-background-color);
+  font-style: italic;
+  line-height: 1.7;
+}
+
+[data-theme="dark"] .glossary__definition-text {
+  background-color: rgba(255, 255, 255, 0.03);
+}
+
+.glossary__definition-source {
+  margin: 0.5rem 0 0 0;
+  font-size: 0.8rem;
+  color: var(--ifm-font-color-base);
+  opacity: 0.6;
+}
+
+.glossary__no-definition {
+  margin: 0.5rem 0 0 0;
+  font-size: 0.85rem;
+  font-style: italic;
+  color: var(--ifm-font-color-base);
+  opacity: 0.5;
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -67,6 +67,13 @@
   text-decoration: underline;
 }
 
+.glossary__codata-label {
+  font-weight: 400;
+  font-size: 0.9em;
+  opacity: 0.5;
+  margin-left: 0.375rem;
+}
+
 .glossary__codata-badge {
   display: inline-flex;
   align-items: center;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -83,6 +83,7 @@
 .glossary__codata-badge:hover {
   opacity: 1;
   text-decoration: none;
+  color: #fff;
 }
 
 .glossary__definition {

--- a/src/theme/DocItem/index.tsx
+++ b/src/theme/DocItem/index.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import DocItem from "@theme-original/DocItem";
+import type {
+  DocItem as DocItemType,
+} from "@theme/DocItem";
+import type { Props } from "@theme/DocItem";
+import { GlossaryBadgeContext, createGlossaryBadgeInfo } from "@site/src/components/GlossaryBadge";
+
+type DocItemContent = Parameters<DocItemType>[0]["content"];
+
+export default function DocItemWrapper(props: Props) {
+  const content = props.content as unknown as {
+    frontMatter: Record<string, unknown>;
+  };
+  const badgeInfo = createGlossaryBadgeInfo(
+    content.frontMatter?.codata_uri as string | undefined,
+  );
+
+  return (
+    <GlossaryBadgeContext.Provider value={badgeInfo}>
+      <DocItem {...props} />
+    </GlossaryBadgeContext.Provider>
+  );
+}

--- a/src/theme/MDXComponents/H1/index.tsx
+++ b/src/theme/MDXComponents/H1/index.tsx
@@ -16,17 +16,20 @@ export default function DocH1({ componentRef, ...rest }: H1Props) {
   }
 
   return (
-    <MDXHeading as="h1" componentRef={componentRef} className={styles.docH1} {...rest}>
+    <MDXHeading
+      as="h1"
+      componentRef={componentRef}
+      className={styles.docH1}
+      {...rest}
+    >
       {rest.children as React.ReactNode}
-      <sup>
-        <a
-          href={badgeInfo.href}
-          className={styles.glossaryLink}
-          title="See definition in the glossary"
-        >
-          <span className={styles.badgeIcon}>?</span>
-        </a>
-      </sup>
+      <a
+        href={badgeInfo.href}
+        className={styles.glossaryLink}
+        title="See definition in the glossary"
+      >
+        <span className={styles.badgeIcon}>?</span>
+      </a>
     </MDXHeading>
   );
 }

--- a/src/theme/MDXComponents/H1/index.tsx
+++ b/src/theme/MDXComponents/H1/index.tsx
@@ -1,0 +1,32 @@
+import { ComponentProps } from "react";
+import MDXHeading from "@theme/MDXComponents/Heading";
+import React from "react";
+import { useGlossaryBadge } from "@site/src/components/GlossaryBadge";
+import styles from "./styles.module.css";
+
+export type H1Props = ComponentProps<"h1"> & {
+  componentRef?: React.RefObject<HTMLHeadingElement>;
+};
+
+export default function DocH1({ componentRef, ...rest }: H1Props) {
+  const badgeInfo = useGlossaryBadge();
+
+  if (!badgeInfo) {
+    return <MDXHeading as="h1" componentRef={componentRef} {...rest} />;
+  }
+
+  return (
+    <MDXHeading as="h1" componentRef={componentRef} className={styles.docH1} {...rest}>
+      {rest.children as React.ReactNode}
+      <sup>
+        <a
+          href={badgeInfo.href}
+          className={styles.glossaryLink}
+          title="See definition in the glossary"
+        >
+          <span className={styles.badgeIcon}>?</span>
+        </a>
+      </sup>
+    </MDXHeading>
+  );
+}

--- a/src/theme/MDXComponents/H1/styles.module.css
+++ b/src/theme/MDXComponents/H1/styles.module.css
@@ -1,14 +1,14 @@
 .docH1 {
-  display: flex;
-  align-items: baseline;
-  gap: 0.25rem;
-  flex-wrap: wrap;
+  margin: 0;
 }
 
 .glossaryLink {
+  margin-left: 0.25rem;
   color: var(--ifm-color-primary-lightest);
   opacity: 0.6;
-  transition: opacity 0.2s ease, color 0.2s ease;
+  transition:
+    opacity 0.2s ease,
+    color 0.2s ease;
 }
 
 .glossaryLink:hover {
@@ -17,6 +17,7 @@
 }
 
 .badgeIcon {
+  vertical-align: text-top;
   display: inline-flex;
   align-items: center;
   justify-content: center;

--- a/src/theme/MDXComponents/H1/styles.module.css
+++ b/src/theme/MDXComponents/H1/styles.module.css
@@ -1,0 +1,31 @@
+.docH1 {
+  display: flex;
+  align-items: baseline;
+  gap: 0.25rem;
+  flex-wrap: wrap;
+}
+
+.glossaryLink {
+  color: var(--ifm-color-primary-lightest);
+  opacity: 0.6;
+  transition: opacity 0.2s ease, color 0.2s ease;
+}
+
+.glossaryLink:hover {
+  opacity: 1;
+  color: var(--ifm-color-primary);
+}
+
+.badgeIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 1.5px solid var(--ifm-color-primary-lightest);
+  font-weight: 700;
+  font-size: 10px;
+  font-family: var(--ifm-font-family-base);
+  line-height: 1;
+}

--- a/src/theme/MDXComponents/index.tsx
+++ b/src/theme/MDXComponents/index.tsx
@@ -1,0 +1,36 @@
+import React, {type ComponentProps} from 'react';
+import Head from '@docusaurus/Head';
+import MDXCode from '@theme/MDXComponents/Code';
+import MDXA from '@theme/MDXComponents/A';
+import MDXPre from '@theme/MDXComponents/Pre';
+import MDXDetails from '@theme/MDXComponents/Details';
+import MDXHeading from '@theme/MDXComponents/Heading';
+import MDXUl from '@theme/MDXComponents/Ul';
+import MDXLi from '@theme/MDXComponents/Li';
+import MDXImg from '@theme/MDXComponents/Img';
+import Admonition from '@theme/Admonition';
+import Mermaid from '@theme/Mermaid';
+import type {MDXComponentsObject} from '@theme/MDXComponents';
+import DocH1 from '@theme/MDXComponents/H1';
+
+const MDXComponents: MDXComponentsObject = {
+  Head,
+  details: MDXDetails,
+  Details: MDXDetails,
+  code: MDXCode,
+  a: MDXA,
+  pre: MDXPre,
+  ul: MDXUl,
+  li: MDXLi,
+  img: MDXImg,
+  h1: ({ componentRef, ...rest }: ComponentProps<'h1'> & { componentRef?: React.RefObject<HTMLHeadingElement> }) => <DocH1 componentRef={componentRef} {...rest} />,
+  h2: (props: ComponentProps<'h2'>) => <MDXHeading as="h2" {...props} />,
+  h3: (props: ComponentProps<'h3'>) => <MDXHeading as="h3" {...props} />,
+  h4: (props: ComponentProps<'h4'>) => <MDXHeading as="h4" {...props} />,
+  h5: (props: ComponentProps<'h5'>) => <MDXHeading as="h5" {...props} />,
+  h6: (props: ComponentProps<'h6'>) => <MDXHeading as="h6" {...props} />,
+  admonition: Admonition,
+  mermaid: Mermaid,
+};
+
+export default MDXComponents;


### PR DESCRIPTION
This PR Creates Glossary and integrate with CODATA.

<img width="851" height="349" alt="image" src="https://github.com/user-attachments/assets/8f97330a-fd16-4d57-b6b7-d0e23fd3e8ea" />

<img width="857" height="369" alt="image" src="https://github.com/user-attachments/assets/dacc6dac-a365-4605-a168-76669b95c40a" />


Fixes #185 



## LLM Summary

---

> ⚠️ **Caveat:** Summary generated by LLM — please verify before use.

**Three key points:**

1. **Glossary feature** — Built a glossary page using the [CODATA RDM-T vocabulary](https://vocabs.ardc.edu.au/show/metacat.2995). Build-time plugin fetches definitions and labels from the CODATA SPARQL endpoint; displays terms with definitions, parenthetical CODATA labels, and `CODATA ↗` badges.

2. **Reference badges on 13 docs** — 13 doc pages are annotated with `for_glossary: true` + `codata_uri`. Each shows an inline `?` icon in the `<h1>` heading linking back to the glossary page (uses `vertical-align: text-top`, flows inline with text).

3. **Supporting changes** — `README.md` includes glossary section, `CONTEXT.md` provides project overview, theme swizzles (`DocItem`, `MDXComponents/H1`) provide the badge context. Definitions fetched automatically at build time.