### PR TITLE
feat: add lock icons to all login-required outbound links

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -88,7 +88,7 @@ const config: Config = {
         { to: "/blog", label: "Blog", position: "left" },
         {
           href: "https://cockpit.research.tue.nl",
-          label: "Research Cockpit",
+          label: "Research Cockpit \u{1F512}",
           position: "right",
         },
 
@@ -119,7 +119,7 @@ const config: Config = {
           title: "TU/e Resources",
           items: [
             {
-              label: "Research Cockpit",
+              label: "Research Cockpit \u{1F512}",
               href: "https://cockpit.research.tue.nl",
             },
             {

--- a/src/components/ApplyERB/index.tsx
+++ b/src/components/ApplyERB/index.tsx
@@ -1,3 +1,5 @@
+import { LockKeyhole } from 'lucide-react';
+
 export default function ApplyERB() {
   return (
     <>
@@ -7,6 +9,7 @@ export default function ApplyERB() {
         target="_blank"
       >
         Apply for an ERB on Research Cockpit
+        <LockKeyhole size={10} strokeWidth={2.5} style={{ marginLeft: '0.25rem' }} />
       </a>
     </>
   );

--- a/src/components/CreateDMP/index.tsx
+++ b/src/components/CreateDMP/index.tsx
@@ -1,3 +1,5 @@
+import { LockKeyhole } from 'lucide-react';
+
 export default function CreateDMP() {
   return (
     <>
@@ -7,6 +9,7 @@ export default function CreateDMP() {
         target="_blank"
       >
         Create a Data Management Plan on Research Cockpit
+        <LockKeyhole size={10} strokeWidth={2.5} style={{ marginLeft: '0.25rem' }} />
       </a>
     </>
   );

--- a/src/components/HighlightCards/index.tsx
+++ b/src/components/HighlightCards/index.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode } from "react";
 import styles from "./styles.module.css";
 import clsx from "clsx";
+import { LockKeyhole } from "lucide-react";
 
 export default function HighlightCards(): ReactNode {
   return (
@@ -21,6 +22,11 @@ export default function HighlightCards(): ReactNode {
                 target="_blank"
               >
                 Go to Research Cockpit
+                <LockKeyhole
+                  size={10}
+                  strokeWidth={2.5}
+                  style={{ marginLeft: "0.50rem" }}
+                />
               </a>
             </div>
           </div>

--- a/src/components/LoginLink/index.tsx
+++ b/src/components/LoginLink/index.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import Link from '@docusaurus/Link';
+import {LockKeyhole} from 'lucide-react';
+import type {Props as LinkProps} from '@theme/MDXComponents/A';
+import styles from './styles.module.css';
+
+const LOGIN_REQUIRED_HOSTS = [
+  'cockpit.research.tue.nl',
+  'gitlab.tue.nl',
+  'tue.atlassian.net',
+];
+
+function isLoginRequired(href: string): boolean {
+  try {
+    const url = new URL(href);
+    return LOGIN_REQUIRED_HOSTS.some(
+      (host) => url.hostname === host || url.hostname.endsWith('.' + host),
+    );
+  } catch {
+    return false;
+  }
+}
+
+export default function LoginLinkWrapper(props: LinkProps): React.ReactNode {
+  const href = props.href ?? '';
+  const showLock = isLoginRequired(href);
+
+  if (!showLock) {
+    return <Link {...props} />;
+  }
+
+  const {children, ...rest} = props;
+  return (
+    <Link {...rest}>
+      <span className={styles.lockLink}>
+        {children}
+        <LockKeyhole
+          className={styles.lockIcon}
+          size={10}
+          strokeWidth={2.5}
+        />
+      </span>
+    </Link>
+  );
+}

--- a/src/components/LoginLink/styles.module.css
+++ b/src/components/LoginLink/styles.module.css
@@ -1,0 +1,11 @@
+.lockLink {
+  display: inline-flex;
+  align-items: flex-start;
+  gap: 0.25rem;
+}
+
+.lockIcon {
+  color: var(--ifm-color-primary-darkest);
+  opacity: 0.5;
+  flex-shrink: 0;
+}

--- a/src/theme/MDXComponents/index.tsx
+++ b/src/theme/MDXComponents/index.tsx
@@ -1,7 +1,6 @@
 import React, {type ComponentProps} from 'react';
 import Head from '@docusaurus/Head';
 import MDXCode from '@theme/MDXComponents/Code';
-import MDXA from '@theme/MDXComponents/A';
 import MDXPre from '@theme/MDXComponents/Pre';
 import MDXDetails from '@theme/MDXComponents/Details';
 import MDXHeading from '@theme/MDXComponents/Heading';
@@ -12,13 +11,14 @@ import Admonition from '@theme/Admonition';
 import Mermaid from '@theme/Mermaid';
 import type {MDXComponentsObject} from '@theme/MDXComponents';
 import DocH1 from '@theme/MDXComponents/H1';
+import LoginLinkWrapper from '@site/src/components/LoginLink';
 
 const MDXComponents: MDXComponentsObject = {
   Head,
   details: MDXDetails,
   Details: MDXDetails,
   code: MDXCode,
-  a: MDXA,
+  a: LoginLinkWrapper,
   pre: MDXPre,
   ul: MDXUl,
   li: MDXLi,


### PR DESCRIPTION
This PR creates the lock icons.

Fixes #208 


----

🤖 List of the pages affected:

| # | Page | Lock icons to check |
|---|------|---------------------|
| 1 | [`/docs/before-research/dmp/`](https://rdm.tue.nl/pr-preview/pr-226/docs/before-research/dmp/) | DMP tool, Research Cockpit, DMP on Research Cockpit (button). Also has `CreateDMP` and `ReadyToStartDMP` CTA buttons. |
| 2 | [`/docs/before-research/ethical-approval/`](https://rdm.tue.nl/pr-preview/pr-226/docs/before-research/ethical-approval/) | Personal data. Also has `ApplyERB` CTA button. |
| 3 | [`/docs/before-research/funder-requirements/`](https://rdm.tue.nl/pr-preview/pr-226/docs/before-research/funder-requirements/) | DMP tool, Research Cockpit. Also has `CreateDMP` CTA button. |
| 4 | [`/docs/learning-resources/booklet/booklet/`](https://rdm.tue.nl/pr-preview/pr-226/docs/learning-resources/booklet/booklet/) | TU/e DMP template, ERB form, Research Cockpit, RAPS, myDRE, Cryptomator Hub, GitLab |
| 5 | [`/docs/privacy/privacy/privacy/`](https://rdm.tue.nl/pr-preview/pr-226/docs/privacy/privacy/privacy/) | Personal Data in Research |
| 6 | [`/docs/during-research/storage-and-sharing/`](https://rdm.tue.nl/pr-preview/pr-226/docs/during-research/storage-and-sharing/) | Normal personal data, special personal data (×3), Research Cockpit |
| 7 | [`/docs/during-research/research-software/`](https://rdm.tue.nl/pr-preview/pr-226/docs/during-research/research-software/) | TU/e GitLab server, GitHub Enterprise, GitLab or GitHub, TU/e GitLab |
| 8 | [`/docs/during-research/data-organization/`](https://rdm.tue.nl/pr-preview/pr-226/docs/during-research/data-organization/) | Hierarchical Data Format (HDF5) |
| 9 | [`/docs/after-research/data-preservation/`](https://rdm.tue.nl/pr-preview/pr-226/docs/after-research/data-preservation/) | TU/e RAPS |
| 10 | [`/docs/intro/tue-policy/`](https://rdm.tue.nl/pr-preview/pr-226/docs/intro/tue-policy/) | Research Cockpit, inline button |

Navbar & footer (every page): "Research Cockpit 🔒" should show the emoji in both the navbar and footer.