### PR TITLE
fix(highlight-cards): use theme-aware background color for dark mode

### DIFF
--- a/src/components/HighlightCards/styles.module.css
+++ b/src/components/HighlightCards/styles.module.css
@@ -7,3 +7,7 @@
   padding: 1.5rem;
   margin: 15px;
 }
+
+:global([data-theme="dark"]) .bg-card {
+  background-color: var(--ifm-card-background-color);
+}


### PR DESCRIPTION



<img width="1197" height="686" alt="image" src="https://github.com/user-attachments/assets/d7e0ee26-5468-40f6-93aa-e81375e196a2" />


Fixes #230 